### PR TITLE
chore: harden clawloop public release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,20 @@ jobs:
           python-version: "3.12"
       - run: pip install build
 
-      - name: No enterprise imports in public code
+      - name: No private imports in public code
         run: |
-          MATCHES=$(grep -rn --include="*.py" -E '^\s*(from|import)\s+enterprise' clawloop/ tests/ examples/ 2>/dev/null | grep -v '\.claude/' || true)
+          MATCHES=$(grep -rn --include="*.py" -E '^\s*(from|import)\s+private_' clawloop/ tests/ examples/ 2>/dev/null | grep -v '\.claude/' || true)
           if [[ -n "$MATCHES" ]]; then
-            echo "::error::Enterprise imports found in public code"
+            echo "::error::Private imports found in public code"
             echo "$MATCHES"
             exit 1
           fi
 
-      - name: No enterprise references in docs
+      - name: No private placeholders in docs
         run: |
-          MATCHES=$(grep -rl "enterprise/" README.md CONTRIBUTING.md examples/ 2>/dev/null | grep -v '\.claude/' || true)
+          MATCHES=$(grep -rl "private/" README.md CONTRIBUTING.md examples/ 2>/dev/null | grep -v '\.claude/' || true)
           if [[ -n "$MATCHES" ]]; then
-            echo "::error::Public docs reference enterprise/"
+            echo "::error::Public docs reference private placeholders"
             echo "$MATCHES"
             exit 1
           fi
@@ -64,11 +64,11 @@ jobs:
             exit 1
           fi
 
-      - name: No residual lfx branding
+      - name: No residual legacy branding
         run: |
           MATCHES=$(grep -rnw --include="*.py" -i 'lfx' clawloop/ tests/ examples/ 2>/dev/null || true)
           if [[ -n "$MATCHES" ]]; then
-            echo "::warning::Residual lfx branding found"
+            echo "::warning::Residual legacy branding found"
             echo "$MATCHES"
           fi
 
@@ -77,7 +77,7 @@ jobs:
           python -m build --sdist --wheel
           python3 -c "
           import tarfile, zipfile, glob, sys
-          PRIVATE = ('enterprise', 'enterprise_clawloop', 'business', 'scripts')
+          PRIVATE = ('private', 'scripts')
           def check(path):
               parts = path.split('/')
               if len(parts) > 1 and '-' in parts[0]: parts = parts[1:]

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,22 @@
-
-# Benchmark artifacts
-# Enterprise code must never exist in public repo
-# IDE
 # OS
-# Python
-# Secrets
 *.egg-info/
 *.pyc
 *.whl
 .DS_Store
+
+# IDE
 .claude
-.env
 .idea/
 .pytest_cache/
 .vscode/
-/enterprise/
-/enterprise_clawloop/
+
+# Secrets
+.env
+
+# Python
 __pycache__/
+
+# Benchmark artifacts
 benchmarks/*/.env
 benchmarks/*/.venv/
 benchmarks/*/output/

--- a/README.md
+++ b/README.md
@@ -200,17 +200,6 @@ and an `EpisodeSummary` containing reward signals. See `clawloop/envs/math.py`
 
 </details>
 
-## Enterprise
-
-Need advanced evolution algorithms, managed training infrastructure, or
-dedicated support? ClawLoop Enterprise extends the community edition with:
-
-- **Advanced evolvers** — SkyDiscover-backed prompt evolution, EvoX, and more
-- **Managed weight training** — hosted LoRA/GRPO pipelines, no GPU management
-- **Priority support and SLA**
-
-Contact [info@aganthos.com](mailto:info@aganthos.com) to learn more.
-
 ## License
 
 ClawLoop is licensed under the [Business Source License 1.1](LICENSE) with

--- a/clawloop/cli.py
+++ b/clawloop/cli.py
@@ -1,4 +1,4 @@
-"""ClawLoop CLI — entry point for run, eval, compare, and gate commands."""
+"""ClawLoop CLI — entry point for run, eval, and benchmark setup commands."""
 
 from __future__ import annotations
 
@@ -52,23 +52,6 @@ def _build_parser() -> argparse.ArgumentParser:
         "--episodes", type=int, default=10, help="Number of episodes"
     )
     eval_p.add_argument("--config", type=str, default=None, help="Config JSON file")
-
-    # -- compare --
-    cmp_p = sub.add_parser(
-        "compare", help="Compare two states on a benchmark"
-    )
-    cmp_p.add_argument("--bench", required=True)
-    cmp_p.add_argument("--state-a", required=True, help="First state config JSON")
-    cmp_p.add_argument("--state-b", required=True, help="Second state config JSON")
-    cmp_p.add_argument("--episodes", type=int, default=10)
-
-    # -- gate --
-    gate_p = sub.add_parser("gate", help="Run deploy-time regression gate")
-    gate_p.add_argument("--candidate", required=True, help="Candidate episodes JSON")
-    gate_p.add_argument(
-        "--production", required=True, help="Production episodes JSON"
-    )
-    gate_p.add_argument("--threshold", type=float, default=0.0)
 
     # -- setup-bench --
     setup_p = sub.add_parser("setup-bench", help="Install benchmark dependencies")
@@ -227,16 +210,6 @@ def cmd_eval(args: argparse.Namespace) -> None:
         print("No episodes collected.")
 
 
-def cmd_compare(args: argparse.Namespace) -> None:
-    print("Compare command: not yet implemented", file=sys.stderr)
-    sys.exit(1)
-
-
-def cmd_gate(args: argparse.Namespace) -> None:
-    print("Gate command: not yet implemented", file=sys.stderr)
-    sys.exit(1)
-
-
 # Benchmark setup registry: bench -> (setup_script_path, uv_sync_extras)
 BENCH_SETUP: dict[str, dict[str, Any]] = {
     "car": {
@@ -310,8 +283,6 @@ def main() -> None:
     handlers = {
         "run": cmd_run,
         "eval": cmd_eval,
-        "compare": cmd_compare,
-        "gate": cmd_gate,
         "setup-bench": cmd_setup_bench,
     }
     handlers[args.command](args)

--- a/clawloop/core/evolver.py
+++ b/clawloop/core/evolver.py
@@ -95,7 +95,7 @@ class Evolver(Protocol):
     Receives episode traces + full harness state, returns holistic
     improvements across playbook, prompts, and paradigm.
 
-    Implementations: LocalEvolver (community), CloudEvolver (enterprise).
+    Implementations: LocalEvolver and other optimization backends.
     """
 
     def evolve(

--- a/clawloop/server.py
+++ b/clawloop/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import secrets
 import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, StreamingResponse
 from starlette.routing import Route
@@ -31,6 +33,33 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 VALID_ROLES = frozenset({"system", "user", "assistant", "tool"})
+LOCAL_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+class ServerAuthMiddleware(BaseHTTPMiddleware):
+    """Protect API routes when a server API key is configured."""
+
+    def __init__(self, app: Any, api_key: str | None) -> None:
+        super().__init__(app)
+        self._api_key = api_key or ""
+
+    async def dispatch(self, request: Request, call_next: Any) -> Any:
+        if not self._api_key:
+            return await call_next(request)
+        if request.url.path.startswith("/dashboard"):
+            return await call_next(request)
+        auth = request.headers.get("authorization", "")
+        scheme, _, token = auth.partition(" ")
+        # SSE (EventSource) cannot send headers; accept ?api_key= for /events
+        qs_key = request.query_params.get("api_key", "")
+        has_valid_header = scheme.lower() == "bearer" and secrets.compare_digest(token, self._api_key)
+        has_valid_qs = qs_key and secrets.compare_digest(qs_key, self._api_key)
+        if not (has_valid_header or has_valid_qs):
+            return JSONResponse(
+                {"error": "unauthorized", "detail": "Invalid or missing API key"},
+                status_code=401,
+            )
+        return await call_next(request)
 
 
 class ClawLoopServer:
@@ -405,6 +434,7 @@ def create_app(
     model: str = "gpt-4o-mini",
     api_base: str | None = None,
     api_key: str | None = None,
+    server_api_key: str | None = None,
     proxy_config: "ProxyConfig | None" = None,
 ) -> Starlette:
     import os
@@ -475,6 +505,7 @@ def create_app(
         server.stop()
 
     app = Starlette(routes=routes, lifespan=lifespan)
+    app.add_middleware(ServerAuthMiddleware, api_key=server_api_key)
 
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists():
@@ -490,7 +521,7 @@ def main() -> None:
     import argparse
     import os
     parser = argparse.ArgumentParser(description="clawloop-server for n8n integration")
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8400)
     parser.add_argument("--seed-prompt", default=None)
     parser.add_argument("--bench", default="n8n")
@@ -498,6 +529,7 @@ def main() -> None:
     parser.add_argument("--model", default=None, help="LLM model for Reflector (litellm format)")
     parser.add_argument("--api-base", default=None, help="LLM API base URL")
     parser.add_argument("--api-key", default=None, help="LLM API key")
+    parser.add_argument("--server-api-key", default=None, help="Protect API endpoints with Authorization: Bearer ...")
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
@@ -506,11 +538,19 @@ def main() -> None:
     api_base = args.api_base or os.environ.get("CLAWLOOP_API_BASE") or None
     api_key = args.api_key or os.environ.get("CLAWLOOP_API_KEY") or None
     model = args.model or os.environ.get("CLAWLOOP_MODEL") or "gpt-4o-mini"
+    server_api_key = args.server_api_key or os.environ.get("CLAWLOOP_SERVER_API_KEY") or None
+
+    if args.host not in LOCAL_HOSTS and not server_api_key:
+        raise SystemExit(
+            "Refusing to bind clawloop-server to a non-local host without "
+            "CLAWLOOP_SERVER_API_KEY or --server-api-key."
+        )
 
     app = create_app(
         seed_prompt_path=args.seed_prompt, bench=args.bench,
         batch_size=args.batch_size, model=model,
         api_base=api_base, api_key=api_key,
+        server_api_key=server_api_key,
     )
     import uvicorn
     uvicorn.run(app, host=args.host, port=args.port)

--- a/clawloop/static/index.html
+++ b/clawloop/static/index.html
@@ -417,7 +417,7 @@ function vote(id, score) {
   const ep = episodes.find(e => e.id === id);
   if (ep) ep._vote = score;
   renderEpisodes();
-  fetch('/feedback', {
+  authFetch('/feedback', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ episode_id: id, score })
@@ -566,7 +566,7 @@ function applyMetrics(m) {
 function startSSE() {
   if (sseSource) { sseSource.close(); sseSource = null; }
   try {
-    sseSource = new EventSource('/events');
+    sseSource = new EventSource('/events' + (_apiKey ? '?api_key=' + encodeURIComponent(_apiKey) : ''));
     sseSource.onopen = () => setConn('sse');
     sseSource.onerror = () => {
       sseSource.close(); sseSource = null;
@@ -596,10 +596,27 @@ function stopPolling() {
   clearInterval(pollState);   pollState   = null;
 }
 
+// ── auth-aware fetch ─────────────────────────────────────────────────────────
+let _apiKey = sessionStorage.getItem('clawloop_api_key') || '';
+
+async function authFetch(url, opts = {}) {
+  const headers = Object.assign({}, opts.headers);
+  if (_apiKey) headers['Authorization'] = 'Bearer ' + _apiKey;
+  const r = await fetch(url, Object.assign({}, opts, { headers }));
+  if (r.status === 401 && !opts._retry) {
+    const key = prompt('ClawLoop API key required:');
+    if (!key) return r;
+    _apiKey = key;
+    sessionStorage.setItem('clawloop_api_key', key);
+    return authFetch(url, Object.assign({}, opts, { _retry: true }));
+  }
+  return r;
+}
+
 // ── fetch helpers ─────────────────────────────────────────────────────────────
 async function loadState() {
   try {
-    const r = await fetch('/state');
+    const r = await authFetch('/state');
     if (!r.ok) return;
     applyState(await r.json());
   } catch {}
@@ -607,7 +624,7 @@ async function loadState() {
 
 async function loadMetrics() {
   try {
-    const r = await fetch('/metrics');
+    const r = await authFetch('/metrics');
     if (!r.ok) return;
     applyMetrics(await r.json());
   } catch {}
@@ -617,7 +634,7 @@ async function loadMetrics() {
 async function doReset() {
   if (!confirm('Reset ClawLoop server? All episodes and playbook will be cleared.')) return;
   try {
-    await fetch('/reset', { method: 'POST' });
+    await authFetch('/reset', { method: 'POST' });
     episodes.length = 0;
     rewardTrend.length = 0;
     seedPrompt = null;
@@ -639,7 +656,7 @@ async function openDetail(id) {
   overlay.classList.add('open');
 
   try {
-    const r = await fetch('/episodes');
+    const r = await authFetch('/episodes');
     if (!r.ok) { detail.innerHTML = '<div class="empty">failed to load</div>'; return; }
     const all = await r.json();
     const ep = all.find(e => e.id === id);
@@ -698,7 +715,7 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDetail(
 // ── load episodes from server (survives page reload) ─────────────────────────
 async function loadEpisodes() {
   try {
-    const r = await fetch('/episodes');
+    const r = await authFetch('/episodes');
     if (!r.ok) return;
     const all = await r.json();
     for (const ep of all) {

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,8 @@ and the server learns in the background.
 
 See [`n8n/README.md`](n8n/README.md) for setup, the importable workflow, and
 a demo script that shows a customer support agent improving across rounds.
+Set `CLAWLOOP_BASE_URL` in n8n if your Docker host cannot reach
+`host.docker.internal`.
 
 ### I have an OpenAI-compatible agent or API
 

--- a/examples/n8n/README.md
+++ b/examples/n8n/README.md
@@ -36,6 +36,8 @@ curl / browser
   a free local setup). The clawloop-server uses litellm for the reflector.
   The n8n workflow calls the LLM directly via OpenAI-compatible HTTP —
   configure `LLM_API_URL` and `LLM_API_KEY` in n8n (see below).
+- `CLAWLOOP_BASE_URL` in n8n if `host.docker.internal` is unavailable on your
+  platform. Example: `http://172.17.0.1:8400`
 
 ## Quick Start
 
@@ -53,7 +55,7 @@ docker run -d --name n8n -p 5678:5678 \
 
 # 3. Start clawloop-server
 #    Set CLAWLOOP_MODEL + the matching provider key (GEMINI_API_KEY, OPENAI_API_KEY, etc.)
-#    Or pass --api-key explicitly.
+#    Or pass --api-key explicitly. The server binds to 127.0.0.1 by default.
 CLAWLOOP_MODEL=gemini/gemini-2.0-flash-lite \
   python -m clawloop.server \
     --seed-prompt seed_prompt.txt \
@@ -63,6 +65,19 @@ CLAWLOOP_MODEL=gemini/gemini-2.0-flash-lite \
 
 # 5. Open the dashboard in your browser
 #    http://localhost:8400/dashboard/
+```
+
+**With Docker n8n (requires non-localhost binding):**
+```bash
+# Docker n8n connects via host.docker.internal, not localhost.
+# Binding to 0.0.0.0 requires an API key for safety.
+CLAWLOOP_SERVER_API_KEY=my-secret-key \
+CLAWLOOP_MODEL=gemini/gemini-2.0-flash-lite \
+  python -m clawloop.server \
+    --host 0.0.0.0 \
+    --seed-prompt seed_prompt.txt \
+    --port 8400
+# Set CLAWLOOP_SERVER_API_KEY in n8n env vars so the workflow can authenticate.
 ```
 
 **With Ollama (free, local):**
@@ -87,9 +102,17 @@ The workflow uses n8n environment variables for LLM configuration:
 - `LLM_API_URL` — defaults to `https://api.openai.com/v1/chat/completions`
 - `LLM_API_KEY` — your API key
 - `LLM_MODEL` — defaults to `gpt-4o-mini`
+- `CLAWLOOP_BASE_URL` — defaults to `http://host.docker.internal:8400`
+- `CLAWLOOP_SERVER_API_KEY` — (optional) API key for the ClawLoop server.
+  Required when clawloop-server is started with `--server-api-key` or
+  `CLAWLOOP_SERVER_API_KEY`. The workflow sends it as `Authorization: Bearer …`.
 
 Set these in n8n: **Settings → Environment Variables**, or pass them to
 `docker run` with `-e`.
+
+On Linux, `host.docker.internal` may not resolve. In that case either:
+- start n8n with `--add-host=host.docker.internal:host-gateway`
+- or set `CLAWLOOP_BASE_URL` to the reachable host address explicitly
 
 No n8n credentials needed — the workflow uses plain HTTP Request nodes.
 

--- a/examples/n8n/customer-support.json
+++ b/examples/n8n/customer-support.json
@@ -16,7 +16,16 @@
     },
     {
       "parameters": {
-        "url": "http://host.docker.internal:8400/state",
+        "url": "={{ $env.CLAWLOOP_BASE_URL || 'http://host.docker.internal:8400' }}/state",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $env.CLAWLOOP_SERVER_API_KEY ? 'Bearer ' + $env.CLAWLOOP_SERVER_API_KEY : '' }}"
+            }
+          ]
+        },
         "options": {}
       },
       "id": "get-state",
@@ -56,7 +65,16 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "http://host.docker.internal:8400/ingest",
+        "url": "={{ $env.CLAWLOOP_BASE_URL || 'http://host.docker.internal:8400' }}/ingest",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $env.CLAWLOOP_SERVER_API_KEY ? 'Bearer ' + $env.CLAWLOOP_SERVER_API_KEY : '' }}"
+            }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\n  \"messages\": [\n    {\"role\": \"system\", \"content\": {{ JSON.stringify($('Get ClawLoop State').item.json.system_prompt) }}},\n    {\"role\": \"user\", \"content\": {{ JSON.stringify($('Webhook').item.json.body.message) }}},\n    {\"role\": \"assistant\", \"content\": {{ JSON.stringify($json.choices[0].message.content) }}}\n  ],\n  \"metadata\": {\n    \"conversation_id\": {{ JSON.stringify($execution.id) }},\n    \"model\": \"{{ $env.LLM_MODEL || 'gpt-4o-mini' }}\"\n  }\n}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,6 @@ include = [
 ]
 exclude = [
     "benchmarks/",
-    "enterprise_clawloop/",
-    "business/",
     "scripts/",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,36 +1,33 @@
 def pytest_collection_modifyitems(session, config, items):
-    """Guard: community tests must never import from enterprise.
+    """Guard: public tests must not import private modules.
 
     Note: This AST-based check catches static imports only. Dynamic imports
     via importlib.import_module() or __import__() are not detected here.
-    The audit script (scripts/audit_public.sh) provides additional coverage.
+    CI provides additional coverage for repository boundary checks.
     """
     import ast
     from pathlib import Path
 
     for item in items:
         fpath = Path(item.fspath)
-        # Only skip the enterprise_clawloop directory itself
-        if str(fpath).startswith("enterprise_clawloop/") or "/enterprise_clawloop/" in str(fpath):
-            continue
         try:
             tree = ast.parse(fpath.read_text())
         except Exception:
             continue
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module and (
-                node.module.startswith("enterprise")
+                node.module.startswith("private_")
             ):
                 raise ValueError(
-                    f"BOUNDARY VIOLATION: {fpath} imports from enterprise "
-                    f"(line {node.lineno}). Community tests must NEVER "
-                    f"import from enterprise/."
+                    f"BOUNDARY VIOLATION: {fpath} imports from private code "
+                    f"(line {node.lineno}). Public tests must not depend on "
+                    f"non-public modules."
                 )
             if isinstance(node, ast.Import):
                 for alias in node.names:
-                    if alias.name.startswith("enterprise"):
+                    if alias.name.startswith("private_"):
                         raise ValueError(
-                            f"BOUNDARY VIOLATION: {fpath} imports from enterprise "
-                            f"(line {node.lineno}). Community tests must NEVER "
-                            f"import from enterprise/."
+                            f"BOUNDARY VIOLATION: {fpath} imports from private code "
+                            f"(line {node.lineno}). Public tests must not depend on "
+                            f"non-public modules."
                         )

--- a/tests/test_evolver_real_llm.py
+++ b/tests/test_evolver_real_llm.py
@@ -6,7 +6,7 @@ Validates the Evolver contract end-to-end with a real LLM:
 3. Multi-cycle learning loop accumulates playbook entries
 4. HarnessSnapshot serialization roundtrip preserves real data
 
-Uses Gemini Flash Lite via GOOGLE_API_KEY. No proxy, no enterprise code.
+Uses Gemini Flash Lite via GOOGLE_API_KEY. No proxy required.
 Skipped automatically if GOOGLE_API_KEY is not set.
 """
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,6 +13,18 @@ def client(tmp_path):
     return TestClient(app)
 
 
+@pytest.fixture
+def protected_client(tmp_path):
+    seed = tmp_path / "seed_prompt.txt"
+    seed.write_text("You are a support agent for Acme Corp.")
+    app = create_app(
+        seed_prompt_path=str(seed),
+        bench="n8n",
+        server_api_key="test-server-key",
+    )
+    return TestClient(app)
+
+
 class TestIngest:
     def test_valid_messages(self, client):
         resp = client.post("/ingest", json={
@@ -84,6 +96,31 @@ class TestState:
         assert isinstance(data["playbook_entries"], list)
         assert isinstance(data["metrics"], dict)
         assert "prompt_updated_at" in data
+
+    def test_requires_auth_when_server_key_is_set(self, protected_client):
+        assert protected_client.get("/state").status_code == 401
+
+    def test_accepts_auth_when_server_key_is_set(self, protected_client):
+        resp = protected_client.get(
+            "/state",
+            headers={"Authorization": "Bearer test-server-key"},
+        )
+        assert resp.status_code == 200
+
+    def test_rejects_malformed_auth_when_server_key_is_set(self, protected_client):
+        resp = protected_client.get(
+            "/state",
+            headers={"Authorization": "Basic test-server-key"},
+        )
+        assert resp.status_code == 401
+
+    def test_accepts_api_key_query_param(self, protected_client):
+        resp = protected_client.get("/state?api_key=test-server-key")
+        assert resp.status_code == 200
+
+    def test_rejects_wrong_query_param(self, protected_client):
+        resp = protected_client.get("/state?api_key=wrong-key")
+        assert resp.status_code == 401
 
 
 class TestReset:


### PR DESCRIPTION
## Summary
- harden `clawloop-server` for public use: default to localhost, add optional API-key protection for API routes
- constant-time bearer token validation (`secrets.compare_digest`) and stricter auth header parsing
- dashboard now prompts for API key when auth is enabled (sessionStorage) and passes it on all fetches including SSE via query param
- n8n workflow nodes send `Authorization: Bearer` header when `CLAWLOOP_SERVER_API_KEY` is set
- n8n README documents `CLAWLOOP_SERVER_API_KEY` env var
- simplify public CLI surface by removing unimplemented commands
- make n8n example portable with `CLAWLOOP_BASE_URL` instead of hardcoded host
- remove non-public split naming from docs, tests, packaging metadata, CI, and audit checks
- tighten `.gitignore` and make public audit fail closed when package build fails
- add sync guardrails: `AGENTS.md`, `sync_to_public.sh`, `where_clawloop.sh`

## Gemini Review Items Addressed
- [x] Dashboard API calls broken under auth — fixed with `authFetch()` wrapper + API key prompt
- [x] SSE EventSource can't send headers — added `?api_key=` query param support in middleware
- [x] n8n README missing `CLAWLOOP_SERVER_API_KEY` docs — added
- [x] n8n workflow get-state node missing auth header — added
- [x] n8n workflow ingest node missing auth header — added

## Validation
- `python -m pytest -q tests/test_server.py` (18 pass including new query-param auth tests)
- `python -m pytest -q tests/test_proxy_config.py tests/test_wrapper.py` (36 pass)
- `python -m clawloop.server --help`
- `python examples/demo_math.py --dry-run`