### PR TITLE
fix: update stale header comments in environments/

### DIFF
--- a/clawloop/environments/_car_purple.py
+++ b/clawloop/environments/_car_purple.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/_car_purple.py
+# clawloop/environments/_car_purple.py
 """A2A purple agent server for CAR-bench with clawloop harness injection."""
 
 from __future__ import annotations

--- a/clawloop/environments/_car_rewards.py
+++ b/clawloop/environments/_car_rewards.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/_car_rewards.py
+# clawloop/environments/_car_rewards.py
 """CAR-bench reward mapping — converts CAR metrics to clawloop RewardSignals."""
 
 from __future__ import annotations

--- a/clawloop/environments/_entropic_purple.py
+++ b/clawloop/environments/_entropic_purple.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/_entropic_purple.py
+# clawloop/environments/_entropic_purple.py
 """A2A purple agent server for Entropic CRMArenaPro with clawloop harness injection.
 
 The entropic green agent sends CRM task prompts as plain text via A2A

--- a/clawloop/environments/_entropic_rewards.py
+++ b/clawloop/environments/_entropic_rewards.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/_entropic_rewards.py
+# clawloop/environments/_entropic_rewards.py
 """Entropic CRMArenaPro reward mapping — 7-dimension scores to clawloop RewardSignals."""
 
 from __future__ import annotations

--- a/clawloop/environments/car.py
+++ b/clawloop/environments/car.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/car.py
+# clawloop/environments/car.py
 """CAR-bench adapter — orchestrates agentbeats-run with clawloop harness injection.
 
 Writes harness prompt to a JSON file, generates a scenario.toml that spawns

--- a/clawloop/environments/entropic.py
+++ b/clawloop/environments/entropic.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/entropic.py
+# clawloop/environments/entropic.py
 """Entropic CRMArenaPro adapter — orchestrates the green agent with clawloop harness.
 
 Starts the entropic green agent as a long-running A2A server, starts a clawloop

--- a/clawloop/environments/openclaw.py
+++ b/clawloop/environments/openclaw.py
@@ -1,4 +1,4 @@
-# clawloop/adapters/openclaw.py
+# clawloop/environments/openclaw.py
 """OpenClaw adapter — runs pi-mono agent tasks via the LLM proxy.
 
 The adapter starts a ProxyApp on an ephemeral port, then spawns a Node runner


### PR DESCRIPTION
7 files in `clawloop/environments/` still had `# clawloop/adapters/...` header comments from before the directory rename. Updated to `# clawloop/environments/...`.

Files: openclaw.py, car.py, entropic.py, _car_purple.py, _car_rewards.py, _entropic_purple.py, _entropic_rewards.py