### PR TITLE
chore: harden repo for public launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
 
       - name: No internal secrets
         run: |
-          MATCHES=$(grep -rl "kuhhandel-bench-key" clawloop/ tests/ examples/ README.md 2>/dev/null || true)
+          MATCHES=$(grep -rln --include="*.py" --include="*.json" --include="*.md" -E '[a-z]+-bench-key' clawloop/ tests/ examples/ README.md 2>/dev/null || true)
           if [[ -n "$MATCHES" ]]; then
-            echo "::error::Internal API key found in public code"
+            echo "::error::Internal API key pattern found in public code"
             echo "$MATCHES"
             exit 1
           fi
@@ -77,11 +77,11 @@ jobs:
           python -m build --sdist --wheel
           python3 -c "
           import tarfile, zipfile, glob, sys
-          PRIVATE = ('private', 'scripts')
+          ALLOWED = {'clawloop', 'tests', 'examples', 'LICENSE', 'README.md', 'CONTRIBUTING.md', 'CHANGELOG.md', 'PKG-INFO'}
           def check(path):
               parts = path.split('/')
               if len(parts) > 1 and '-' in parts[0]: parts = parts[1:]
-              return len(parts) > 0 and parts[0] in PRIVATE
+              return len(parts) > 0 and parts[0] not in ALLOWED
           for f in glob.glob('dist/*.tar.gz'):
               for m in tarfile.open(f).getmembers():
                   if check(m.name): print(f'LEAK: {m.name}'); sys.exit(1)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,11 @@ jobs:
         run: |
           python3 -c "
           import tarfile, zipfile, glob, sys
-          PRIVATE = ('enterprise', 'enterprise_clawloop', 'business', 'scripts')
+          ALLOWED = {'clawloop', 'tests', 'examples', 'LICENSE', 'README.md', 'CONTRIBUTING.md', 'CHANGELOG.md', 'PKG-INFO'}
           def check(path):
               parts = path.split('/')
               if len(parts) > 1 and '-' in parts[0]: parts = parts[1:]
-              return len(parts) > 0 and parts[0] in PRIVATE
+              return len(parts) > 0 and parts[0] not in ALLOWED
           for f in glob.glob('dist/*.tar.gz'):
               for m in tarfile.open(f).getmembers():
                   if check(m.name): print(f'LEAK: {m.name}'); sys.exit(1)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/clawloop/environments/car.py
+++ b/clawloop/environments/car.py
@@ -37,9 +37,13 @@ class CARAdapter(EnvAdapter):
 
     def setup(self, config: dict[str, Any]) -> None:
         self._model = config.get("model", "anthropic/claude-haiku-4-5-20251001")
-        self._car_bench_path = Path(
-            config.get("car_bench_path", "benchmarks/a2a/car-bench")
-        )
+        car_bench_path = config.get("car_bench_path")
+        if not car_bench_path:
+            raise ValueError(
+                "car_bench_path is required in config — "
+                "point it at your local clone of CAR-bench"
+            )
+        self._car_bench_path = Path(car_bench_path)
         self._output_dir = Path(
             config.get("output", f"./runs/car/{int(time.time())}")
         )

--- a/clawloop/environments/entropic.py
+++ b/clawloop/environments/entropic.py
@@ -109,9 +109,13 @@ class EntropicAdapter(EnvAdapter):
 
     def setup(self, config: dict[str, Any]) -> None:
         self._model = config.get("model", "anthropic/claude-haiku-4-5-20251001")
-        self._bench_path = Path(
-            config.get("entropic_bench_path", "benchmarks/a2a/entropic-crmarenapro")
-        )
+        entropic_bench_path = config.get("entropic_bench_path")
+        if not entropic_bench_path:
+            raise ValueError(
+                "entropic_bench_path is required in config — "
+                "point it at your local clone of entropic-crmarenapro"
+            )
+        self._bench_path = Path(entropic_bench_path)
         self._output_dir = Path(
             config.get("output", f"./runs/entropic/{int(time.time())}")
         )

--- a/examples/recipes/SETUP_HARBOR.md
+++ b/examples/recipes/SETUP_HARBOR.md
@@ -93,9 +93,8 @@ To change provider, edit the `trial_config` in the recipe or pass
 ## 5. Lambda GPU Box Setup
 
 ```bash
-# Already done if you followed scripts/gpu_validation/setup.sh
 # Just add Harbor:
-source ~/aganthos/.venv/bin/activate
+source ~/clawloop/.venv/bin/activate
 uv pip install harbor
 
 # Docker should already be running
@@ -105,7 +104,7 @@ docker ps
 harbor datasets download bfcl_parity@1.0 -o ~/data/bfcl_parity
 
 # Run weight training
-cd ~/aganthos
+cd ~/clawloop
 PYTHONPATH=$PWD:$PYTHONPATH python examples/recipes/harbor_bfcl.py \
     --mode weight \
     --task-dir ~/data/bfcl_parity \


### PR DESCRIPTION
## Summary
- CI/publish package audits now use an allowlist (no internal dir names leaked)
- Genericized internal secret check (no literal key names in CI)
- Benchmark adapters require explicit paths instead of fragile relative defaults
- Fixed internal `~/aganthos` paths in SETUP_HARBOR.md
- Added CODE_OF_CONDUCT.md (Contributor Covenant v2.1)

## What was audited
Full security + UX review of the repo before flipping to public:
- Zero real secrets, credentials, or personal info
- No enterprise_clawloop imports in source
- No DGM-H/ShinkaEvolve/proprietary references
- License, README, docs, tests, CI, SECURITY.md, CONTRIBUTING.md all in good shape

## Remaining manual step
- Update GitHub About description (layers != loop metaphor)