### PR TITLE
feat: add EnterpriseOps-Gym adapter and e2e test

### DIFF
--- a/clawloop/environments/__init__.py
+++ b/clawloop/environments/__init__.py
@@ -2,5 +2,17 @@
 
 from clawloop.environments.base import EnvAdapter
 from clawloop.environments.harbor import HarborAdapter, HarborTaskEnvironment
+from clawloop.environments.enterpriseops_gym import (
+    EnterpriseOpsGymAdapter,
+    EnterpriseOpsGymEnvironment,
+    build_adapter_from_hf,
+)
 
-__all__ = ["EnvAdapter", "HarborAdapter", "HarborTaskEnvironment"]
+__all__ = [
+    "EnvAdapter",
+    "HarborAdapter",
+    "HarborTaskEnvironment",
+    "EnterpriseOpsGymAdapter",
+    "EnterpriseOpsGymEnvironment",
+    "build_adapter_from_hf",
+]

--- a/clawloop/environments/enterpriseops_gym.py
+++ b/clawloop/environments/enterpriseops_gym.py
@@ -1,0 +1,342 @@
+"""EnterpriseOps-Gym environment adapter — runs enterprise benchmark tasks, produces ClawLoop Episodes."""
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from clawloop.core.episode import Episode, EpisodeSummary, Message, StepMeta
+from clawloop.core.reward import RewardSignal
+from clawloop.core.types import SampleContext
+from clawloop.utils.async_bridge import run_async
+
+if TYPE_CHECKING:
+    from clawloop.core.loop import AgentState
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ensure_gym_on_path(gym_root: Path) -> None:
+    """Add the EnterpriseOps-Gym repo root to sys.path so its modules resolve.
+
+    The gym is not an installable package, so we add its root to sys.path.
+    Uses append (not insert) to minimize shadowing risk from generic module
+    names like 'evaluate' and 'orchestrators'.
+    """
+    root_str = str(gym_root)
+    if root_str not in sys.path:
+        sys.path.append(root_str)
+
+
+def _conversation_flow_to_messages(flow: list[dict]) -> list[Message]:
+    """Convert EnterpriseOps-Gym conversation_flow dicts into ClawLoop Messages."""
+    msgs: list[Message] = []
+    for entry in flow:
+        entry_type = entry.get("type", "")
+        if entry_type == "system_message":
+            msgs.append(Message(role="system", content=entry.get("content", "")))
+        elif entry_type == "user_message":
+            msgs.append(Message(role="user", content=entry.get("content", "")))
+        elif entry_type == "ai_message":
+            msgs.append(Message(role="assistant", content=entry.get("content", "")))
+        elif entry_type == "tool_result":
+            result_data = entry.get("result", {})
+            content = json.dumps(result_data.get("result", {})) if isinstance(result_data, dict) else str(result_data)
+            msgs.append(Message(role="tool", content=content, name=entry.get("tool_name", "")))
+    return msgs
+
+
+def _compute_step_boundaries(messages: list[Message]) -> list[int]:
+    boundaries: list[int] = []
+    for i, msg in enumerate(messages):
+        if msg.role == "user" and (i == 0 or messages[i - 1].role != "user"):
+            boundaries.append(i)
+    if not boundaries and messages:
+        boundaries = [0]
+    return boundaries
+
+
+def _build_steps(step_boundaries: list[int], reward: float) -> list[StepMeta]:
+    if not step_boundaries:
+        return []
+    steps = []
+    for i in range(len(step_boundaries)):
+        is_terminal = i == len(step_boundaries) - 1
+        steps.append(StepMeta(t=i, reward=reward if is_terminal else 0.0,
+                              done=is_terminal, timing_ms=0.0))
+    return steps
+
+
+# ---------------------------------------------------------------------------
+# Single-task environment
+# ---------------------------------------------------------------------------
+
+class EnterpriseOpsGymEnvironment:
+    """Wraps a single EnterpriseOps-Gym task config and runs it via BenchmarkExecutor."""
+
+    def __init__(
+        self,
+        config_path: Path,
+        llm_config_path: Path,
+        gym_root: Path,
+        *,
+        orchestrator: str = "react",
+    ):
+        self._config_path = Path(config_path)
+        self._llm_config_path = Path(llm_config_path)
+        self._gym_root = Path(gym_root)
+        self._orchestrator = orchestrator
+        _ensure_gym_on_path(self._gym_root)
+
+    @property
+    def task_id(self) -> str:
+        return self._config_path.stem
+
+    async def run_episode(self, agent_state: "AgentState") -> Episode:
+        _ensure_gym_on_path(self._gym_root)
+        from benchmark.executor import BenchmarkExecutor
+        from evaluate import load_config
+        from benchmark_utils import load_llm_configs
+        from orchestrators.react import ReactOrchestrator
+        from orchestrators.planner_react import PlannerReactOrchestrator
+        from orchestrators.decomposing_planner import DecomposingPlannerOrchestrator
+
+        ORCHESTRATOR_MAP = {
+            "react": ReactOrchestrator,
+            "planner_react": PlannerReactOrchestrator,
+            "decomposing": DecomposingPlannerOrchestrator,
+        }
+
+        try:
+            config = load_config(str(self._config_path))
+        except Exception as e:
+            log.error("Failed to load task config %s: %s", self._config_path, e)
+            return self._build_episode(agent_state, filtered=True,
+                                       metadata={"error": "config_load_failed", "detail": str(e)})
+
+        # --- Inject harness system prompt ---
+        if hasattr(agent_state, "harness") and agent_state.harness:
+            try:
+                sample_result = agent_state.harness.sample(
+                    SampleContext(bench=self.task_id))
+                prompt = sample_result.result().output
+                if not prompt:
+                    sample_result = agent_state.harness.sample(
+                        SampleContext(bench="enterpriseops-gym"))
+                    prompt = sample_result.result().output
+                if prompt:
+                    config.system_prompt = prompt
+            except Exception:
+                log.debug("Failed to sample system prompt from harness", exc_info=True)
+
+        # Force single run per episode (state isolation)
+        config.number_of_runs = 1
+
+        try:
+            llm_configs = load_llm_configs(str(self._llm_config_path))
+            llm_config = llm_configs[0]
+        except Exception as e:
+            log.error("Failed to load LLM config %s: %s", self._llm_config_path, e)
+            return self._build_episode(agent_state, filtered=True,
+                                       metadata={"error": "llm_config_failed", "detail": str(e)})
+
+        orchestrator_class = ORCHESTRATOR_MAP.get(self._orchestrator, ReactOrchestrator)
+
+        executor = BenchmarkExecutor(
+            config,
+            llm_config=llm_config,
+            orchestrator_class=orchestrator_class,
+            config_path=str(self._config_path),
+        )
+
+        try:
+            result = await executor.execute_benchmark()
+        except Exception as e:
+            log.error("Executor failed for task %s: %s", self.task_id, e)
+            return self._build_episode(agent_state, filtered=True,
+                                       metadata={"error": "executor_failed", "detail": str(e)})
+
+        # Extract the first (and only) run result
+        runs = result.get("runs", [])
+        if not runs:
+            return self._build_episode(agent_state, filtered=True,
+                                       metadata={"error": "no_runs_returned"})
+
+        run = runs[0]
+
+        # Infra error → filtered
+        if run.get("error"):
+            return self._build_episode(agent_state, filtered=True,
+                                       metadata={"error": "run_error", "detail": run["error"]})
+
+        # Build Episode from conversation flow and verification results
+        conversation_flow = run.get("conversation_flow", [])
+        verification = run.get("verification_summary", {})
+        pass_rate = verification.get("pass_rate", 0.0)
+
+        # Map pass_rate [0, 1] → reward [-1, 1]
+        reward = (pass_rate * 2.0) - 1.0
+
+        messages = _conversation_flow_to_messages(conversation_flow)
+        step_boundaries = _compute_step_boundaries(messages)
+        steps = _build_steps(step_boundaries, reward)
+
+        summary = EpisodeSummary(
+            score_breakdown=run.get("verification_results"),
+        )
+        summary.signals["outcome"] = RewardSignal(
+            name="outcome", value=reward, confidence=1.0,
+        )
+
+        metadata: dict[str, Any] = {
+            "pass_rate": pass_rate,
+            "overall_success": run.get("overall_success", False),
+            "tools_used": run.get("tools_used", []),
+            "execution_time_ms": run.get("execution_time_ms", 0),
+            "verification_summary": verification,
+        }
+
+        state_id = ""
+        if hasattr(agent_state, "state_id") and callable(agent_state.state_id):
+            try:
+                state_id = agent_state.state_id().combined_hash
+            except Exception:
+                log.debug("Failed to compute state_id", exc_info=True)
+
+        return Episode(
+            id=uuid4().hex,
+            state_id=state_id or "",
+            task_id=self.task_id,
+            bench="enterpriseops-gym",
+            messages=messages,
+            step_boundaries=step_boundaries,
+            steps=steps,
+            summary=summary,
+            metadata=metadata,
+        )
+
+    def _build_episode(self, agent_state: "AgentState", *, filtered: bool = False,
+                       reward: float = 0.0, metadata: dict | None = None) -> Episode:
+        summary = EpisodeSummary(filtered=filtered)
+        if not filtered:
+            summary.signals["outcome"] = RewardSignal(
+                name="outcome", value=reward, confidence=1.0,
+            )
+        state_id = ""
+        if hasattr(agent_state, "state_id") and callable(agent_state.state_id):
+            try:
+                state_id = agent_state.state_id().combined_hash
+            except Exception:
+                pass
+        return Episode(
+            id=uuid4().hex, state_id=state_id or "", task_id=self.task_id,
+            bench="enterpriseops-gym", messages=[], step_boundaries=[],
+            steps=[], summary=summary, metadata=metadata or {},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Adapter (sync wrapper, implements AdapterLike)
+# ---------------------------------------------------------------------------
+
+class EnterpriseOpsGymAdapter:
+    """Sync adapter for EnterpriseOps-Gym. Implements AdapterLike for learning_loop.
+
+    Wraps a set of task configs and runs them sequentially via BenchmarkExecutor.
+    Each run creates and cleans up its own database (state isolation is handled
+    by the benchmark's create_database_from_file / delete_database lifecycle).
+
+    License note: EnterpriseOps-Gym is CC BY-NC 4.0 (non-commercial use only).
+    """
+
+    def __init__(self, envs: list[EnterpriseOpsGymEnvironment]):
+        self._envs: dict[str, EnterpriseOpsGymEnvironment] = {}
+        for env in envs:
+            if env.task_id in self._envs:
+                raise ValueError(f"Duplicate task_id {env.task_id!r}")
+            self._envs[env.task_id] = env
+
+    @property
+    def task_ids(self) -> list[str]:
+        return list(self._envs.keys())
+
+    def run_episode(self, task: str, agent_state: "AgentState") -> Episode:
+        return run_async(self._envs[task].run_episode(agent_state))
+
+    def run_batch(self, agent_state: "AgentState", tasks: list[str],
+                  n_per_task: int = 1) -> list[Episode]:
+        # Sequential execution — MCP servers are stateful, parallel runs
+        # against the same domain risk state contamination.
+        episodes: list[Episode] = []
+        for task in tasks:
+            for _ in range(n_per_task):
+                episodes.append(self.run_episode(task, agent_state))
+        return episodes
+
+
+# ---------------------------------------------------------------------------
+# Factory: build adapter from HuggingFace dataset
+# ---------------------------------------------------------------------------
+
+def build_adapter_from_hf(
+    domain: str,
+    llm_config_path: str | Path,
+    gym_root: str | Path,
+    *,
+    mode: str = "oracle",
+    hf_dataset: str = "ServiceNow-AI/EnterpriseOps-Gym",
+    orchestrator: str = "react",
+    max_tasks: int | None = None,
+) -> tuple[EnterpriseOpsGymAdapter, list[str]]:
+    """Download task configs from HuggingFace and build an adapter.
+
+    Returns (adapter, task_ids) ready for learning_loop().
+    """
+    from datasets import load_dataset as hf_load_dataset
+
+    _ensure_gym_on_path(Path(gym_root))
+
+    tmp_dir = tempfile.mkdtemp(prefix="clawloop_eog_")
+    atexit.register(shutil.rmtree, tmp_dir, True)
+    json_string_fields = {"gym_servers_config", "verifiers"}
+    hf_only_fields = {"task_id", "domain"}
+
+    log.info("Loading EnterpriseOps-Gym tasks: dataset=%s mode=%s domain=%s",
+             hf_dataset, mode, domain)
+    hf_ds = hf_load_dataset(hf_dataset, mode, split=domain)
+
+    envs: list[EnterpriseOpsGymEnvironment] = []
+    for i, row in enumerate(hf_ds):
+        if max_tasks is not None and i >= max_tasks:
+            break
+        task_id = row.get("task_id", f"task_{i}")
+        file_name = f"{mode}__{domain}__{task_id}.json"
+        task_dict = {}
+        for k, v in row.items():
+            if k in hf_only_fields:
+                continue
+            if k in json_string_fields and isinstance(v, str):
+                v = json.loads(v)
+            task_dict[k] = v
+        config_path = Path(tmp_dir) / file_name
+        with open(config_path, "w") as f:
+            json.dump(task_dict, f)
+        envs.append(EnterpriseOpsGymEnvironment(
+            config_path=config_path,
+            llm_config_path=Path(llm_config_path),
+            gym_root=Path(gym_root),
+            orchestrator=orchestrator,
+        ))
+
+    log.info("Built %d task environments in %s", len(envs), tmp_dir)
+    adapter = EnterpriseOpsGymAdapter(envs)
+    return adapter, adapter.task_ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,6 @@ constraint-dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "e2e: end-to-end tests requiring Docker, network, and API keys",
+]

--- a/tests/test_e2e_enterpriseops_gym.py
+++ b/tests/test_e2e_enterpriseops_gym.py
@@ -1,0 +1,343 @@
+"""End-to-end test: EnterpriseOps-Gym (Teams domain) + ClawLoop harness learning.
+
+Requires:
+- Docker with the Teams MCP server image pulled
+- ANTHROPIC_API_KEY env var (or an LLM config file)
+- Network access to HuggingFace for dataset download
+
+Run with:
+    pytest tests/test_e2e_enterpriseops_gym.py -m e2e -s --timeout=600
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from clawloop.core.loop import AgentState, learning_loop
+from clawloop.core.episode import Episode
+from clawloop.learning_layers.harness import Harness
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DOCKER_IMAGE = "shivakrishnareddyma225/enterpriseops-gym-mcp-teams:latest"
+CONTAINER_NAME = "clawloop-e2e-eog-teams"
+GYM_ROOT = Path(__file__).resolve().parent.parent / "benchmarks" / "enterpriseops-gym"
+HF_DATASET = "ServiceNow-AI/EnterpriseOps-Gym"
+DOMAIN = "teams"
+MODE = "oracle"
+N_TASKS = 3
+N_ITERATIONS = 2
+N_EPISODES = 2
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _docker_available() -> bool:
+    try:
+        subprocess.run(["docker", "info"], capture_output=True, check=True, timeout=10)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _image_available(image: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", image],
+            capture_output=True, text=True, check=True, timeout=10,
+        )
+        return bool(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def _wait_for_server(port: int, timeout: float = 60.0) -> bool:
+    """Poll until the MCP server responds on the given port."""
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        try:
+            with socket.create_connection(("localhost", port), timeout=2):
+                return True
+        except OSError:
+            time.sleep(1)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# LLM config helper
+# ---------------------------------------------------------------------------
+
+def _proxy_available() -> bool:
+    """Check if a local OpenAI-compatible proxy is running (configured via env vars)."""
+    url = os.environ.get("LLM_PROXY_URL", "")
+    key = os.environ.get("LLM_PROXY_KEY", "")
+    if not url or not key:
+        return False
+    try:
+        import httpx
+        r = httpx.get(f"{url}/models",
+                      headers={"Authorization": f"Bearer {key}"}, timeout=5)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+def _create_llm_config(tmp_dir: Path) -> Path:
+    """Create an LLM config for the benchmark agent.
+
+    Tries (in order):
+    1. Local proxy via LLM_PROXY_URL + LLM_PROXY_KEY + LLM_PROXY_MODEL env vars
+    2. Google Gemini flash lite via GOOGLE_API_KEY / GEMINI_API_KEY
+    3. Anthropic Haiku via ANTHROPIC_API_KEY
+    """
+    proxy_url = os.environ.get("LLM_PROXY_URL", "")
+    proxy_key = os.environ.get("LLM_PROXY_KEY", "")
+    proxy_model = os.environ.get("LLM_PROXY_MODEL", "claude-haiku-4-5-20251001")
+
+    if proxy_url and proxy_key and _proxy_available():
+        config = {
+            "llm_provider": "vllm",
+            "llm_model": proxy_model,
+            "llm_api_key": proxy_key,
+            "llm_api_endpoint": proxy_url,
+            "temperature": 0.1,
+            "max_tokens": 8192,
+        }
+    else:
+        google_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY", "")
+        anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if google_key:
+            config = {
+                "llm_provider": "google",
+                "llm_model": "gemini-2.0-flash-lite",
+                "llm_api_key": google_key,
+                "temperature": 0.1,
+                "max_tokens": 8192,
+            }
+        elif anthropic_key:
+            config = {
+                "llm_provider": "anthropic",
+                "llm_model": "claude-haiku-4-5-20251001",
+                "llm_api_key": anthropic_key,
+                "temperature": 0.1,
+                "max_tokens": 8192,
+            }
+        else:
+            pytest.skip("No LLM configured: set LLM_PROXY_URL+LLM_PROXY_KEY, GOOGLE_API_KEY, or ANTHROPIC_API_KEY")
+
+    config_path = tmp_dir / "llm_config.json"
+    config_path.write_text(json.dumps(config))
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def docker_teams_server():
+    """Start the Teams MCP server in Docker, yield the port, stop on teardown."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    if not _image_available(DOCKER_IMAGE):
+        pytest.skip(f"Docker image {DOCKER_IMAGE} not pulled")
+
+    port = _find_free_port()
+    log.info("Starting Teams MCP server on port %d", port)
+
+    # Stop any leftover container from a previous run
+    subprocess.run(
+        ["docker", "rm", "-f", CONTAINER_NAME],
+        capture_output=True, timeout=10,
+    )
+
+    subprocess.run(
+        [
+            "docker", "run", "-d",
+            "--name", CONTAINER_NAME,
+            "-p", f"{port}:8005",
+            DOCKER_IMAGE,
+        ],
+        check=True, capture_output=True, timeout=30,
+    )
+
+    if not _wait_for_server(port, timeout=90):
+        # Grab logs for debugging, then clean up before failing
+        logs = subprocess.run(
+            ["docker", "logs", CONTAINER_NAME],
+            capture_output=True, text=True, timeout=10,
+        )
+        subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, timeout=10)
+        pytest.fail(f"Teams MCP server failed to start on port {port}.\nLogs:\n{logs.stdout}\n{logs.stderr}")
+
+    log.info("Teams MCP server ready on port %d", port)
+    yield port
+
+    # Teardown
+    subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True, timeout=10)
+
+
+@pytest.fixture(scope="module")
+def llm_config_path(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("eog_llm")
+    return _create_llm_config(tmp_dir)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestEnterpriseOpsGymHarnessLearning:
+    """Real e2e: Docker MCP server + real LLM + harness learning loop."""
+
+    def test_harness_learns_from_enterprise_tasks(
+        self, docker_teams_server, llm_config_path, tmp_path,
+    ):
+        from clawloop.environments.enterpriseops_gym import build_adapter_from_hf
+
+        port = docker_teams_server
+
+        # Patch the MCP server URL in the task configs.
+        # build_adapter_from_hf downloads configs from HF — we need to
+        # post-process them to point at our local Docker container.
+        adapter, task_ids = build_adapter_from_hf(
+            domain=DOMAIN,
+            llm_config_path=llm_config_path,
+            gym_root=GYM_ROOT,
+            mode=MODE,
+            max_tasks=N_TASKS,
+        )
+
+        # Patch MCP server URLs in all task configs to point at our container
+        for env in adapter._envs.values():
+            config_path = env._config_path
+            with open(config_path) as f:
+                config_data = json.load(f)
+
+            # Patch single-gym URL
+            if "mcp_server_url" in config_data:
+                config_data["mcp_server_url"] = f"http://localhost:{port}"
+
+            # Patch multi-gym URLs
+            if "gym_servers_config" in config_data:
+                for server in config_data["gym_servers_config"]:
+                    server["mcp_server_url"] = f"http://localhost:{port}"
+
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
+        # Build harness with a base system prompt and reflector
+        from clawloop.llm import LiteLLMClient
+        # Use cheapest available model for reflector
+        proxy_url = os.environ.get("LLM_PROXY_URL", "")
+        proxy_key = os.environ.get("LLM_PROXY_KEY", "")
+        proxy_model = os.environ.get("LLM_PROXY_MODEL", "claude-haiku-4-5-20251001")
+
+        if proxy_url and proxy_key and _proxy_available():
+            reflector_client = LiteLLMClient(
+                model=f"openai/{proxy_model}",
+                api_base=proxy_url,
+                api_key=proxy_key,
+            )
+        elif os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"):
+            reflector_client = LiteLLMClient(model="gemini/gemini-2.0-flash-lite")
+        else:
+            reflector_client = LiteLLMClient(model="anthropic/claude-haiku-4-5-20251001")
+
+        harness = Harness(
+            system_prompts={"enterpriseops-gym": (
+                "You are an enterprise operations assistant. Use the available tools "
+                "to complete tasks in the Teams application. Think step by step about "
+                "what data you need and which tools to call."
+            )},
+        )
+
+        # Set up evolver with reflector for learning
+        from clawloop.harness_backends.local import LocalEvolver
+        from clawloop.core.reflector import Reflector
+
+        reflector = Reflector(client=reflector_client)
+        evolver = LocalEvolver(reflector=reflector)
+        harness.evolver = evolver
+
+        agent_state = AgentState(harness=harness)
+
+        # Limit tasks to what we have
+        tasks_to_use = task_ids[:N_TASKS]
+
+        log.info(
+            "Starting learning loop: %d tasks, %d iterations, %d episodes/iter",
+            len(tasks_to_use), N_ITERATIONS, N_EPISODES,
+        )
+
+        # --- Pre-flight: verify adapter produces valid episodes ---
+        preflight_episode = adapter.run_episode(tasks_to_use[0], agent_state)
+        assert isinstance(preflight_episode, Episode), (
+            f"Adapter should return Episode, got {type(preflight_episode)}"
+        )
+        assert preflight_episode.bench == "enterpriseops-gym"
+        assert preflight_episode.task_id, "Episode must have a task_id"
+
+        has_messages = len(preflight_episode.messages) > 0
+        is_filtered = preflight_episode.summary.filtered
+        log.info(
+            "Preflight episode: %d messages, filtered=%s, reward=%.3f",
+            len(preflight_episode.messages), is_filtered,
+            preflight_episode.summary.effective_reward() if not is_filtered else 0.0,
+        )
+
+        # At minimum the adapter should return a structurally valid episode
+        # (even if filtered due to infra issues, the shape must be correct)
+        assert preflight_episode.id, "Episode must have an id"
+        if not is_filtered:
+            assert has_messages, "Non-filtered episode should have messages from MCP interaction"
+
+        # --- Run the learning loop ---
+        agent_state, state_id = learning_loop(
+            adapter=adapter,
+            agent_state=agent_state,
+            tasks=tasks_to_use,
+            n_episodes=N_EPISODES,
+            n_iterations=N_ITERATIONS,
+            active_layers=["harness"],
+            output_dir=str(tmp_path / "eog_run"),
+        )
+
+        # --- Assertions ---
+
+        # 1. State ID changed (learning happened)
+        assert state_id.combined_hash != AgentState().state_id().combined_hash, (
+            "State ID should change after learning — harness should have been modified"
+        )
+
+        # 2. Playbook version incremented (forward_backward + optim_step ran)
+        assert agent_state.harness.playbook_version > 0, (
+            "Playbook version should have incremented — "
+            "forward_backward + optim_step should have run"
+        )
+
+        # 3. Log results for manual inspection
+        playbook = agent_state.harness.playbook
+        n_entries = len(playbook.entries)
+        log.info(
+            "E2E test passed: %d playbook entries, version=%d, state_id=%s",
+            n_entries, agent_state.harness.playbook_version, state_id.combined_hash[:12],
+        )


### PR DESCRIPTION
## Summary
- Add [EnterpriseOps-Gym](https://github.com/ServiceNow/EnterpriseOps-Gym) as a git submodule at `benchmarks/enterpriseops-gym`
- New environment adapter (`clawloop/environments/enterpriseops_gym.py`) implementing `AdapterLike` protocol
- Real end-to-end test exercising Docker MCP server + LLM agent + harness learning loop on the Teams domain

## Design
- **Adapter** wraps their ReAct orchestrator, injects harness system prompt via mutable `BenchmarkConfig.system_prompt`
- **State isolation**: sequential episode execution + per-run DB creation/cleanup (built into their framework)
- **Failure model**: mirrors Harbor — infra errors → `filtered=True`, agent failures → trainable episodes
- **Factory**: `build_adapter_from_hf()` downloads tasks from HuggingFace and builds the adapter
- **License**: EnterpriseOps-Gym is CC BY-NC 4.0 (benchmark submodule only, not redistributed)

## Test plan
- [x] E2e test passes: Docker Teams MCP + haiku + `learning_loop()` → playbook updated
- [x] 939 existing tests pass, 0 regressions
- [x] No hardcoded credentials — LLM config via env vars (`LLM_PROXY_URL`/`GOOGLE_API_KEY`/`ANTHROPIC_API_KEY`)
- [ ] Reviewer: verify Docker image `shivakrishnareddyma225/enterpriseops-gym-mcp-teams:latest` pulls and runs
- [ ] Run `pytest tests/test_e2e_enterpriseops_gym.py -m e2e -s --timeout=600` with LLM env vars set

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>