### PR TITLE
feat: TauBench 3 adapter with harness learning integration

### DIFF
--- a/clawloop/cli.py
+++ b/clawloop/cli.py
@@ -96,14 +96,15 @@ def _load_config(path: str | None) -> dict[str, Any]:
         sys.exit(1)
 
 
-def _build_reflector(config: dict[str, Any]) -> Any | None:
-    """Create a Reflector with LiteLLMClient if api_base is configured."""
+def _build_evolver(config: dict[str, Any]) -> Any | None:
+    """Create a LocalEvolver with Reflector if api_base is configured."""
     api_base = config.get("api_base")
     if not api_base:
         log.warning("No api_base in config — Reflector disabled (no learning)")
         return None
 
     from clawloop.core.reflector import Reflector, ReflectorConfig
+    from clawloop.harness_backends.local import LocalEvolver
     from clawloop.llm import LiteLLMClient
 
     model = config.get("reflector_model", config.get("model", "anthropic/claude-haiku-4-5-20251001"))
@@ -114,7 +115,8 @@ def _build_reflector(config: dict[str, Any]) -> Any | None:
     )
     log.info("Reflector enabled: model=%s via %s", model, api_base)
     rbs = config.get("reflection_batch_size", 1)
-    return Reflector(client=client, config=ReflectorConfig(reflection_batch_size=rbs))
+    reflector = Reflector(client=client, config=ReflectorConfig(reflection_batch_size=rbs))
+    return LocalEvolver(reflector=reflector)
 
 
 def _ensure_output_dir(config: dict[str, Any], bench: str) -> None:
@@ -148,10 +150,10 @@ def cmd_run(args: argparse.Namespace) -> None:
     if args.seed is not None:
         random.seed(args.seed)
 
-    # Wire Reflector into harness for ICL learning
-    reflector = _build_reflector(config)
-    agent_state = AgentState()
-    agent_state.harness.reflector = reflector
+    # Wire LocalEvolver (with Reflector) into harness for ICL learning
+    from clawloop.learning_layers.harness import Harness
+    evolver = _build_evolver(config)
+    agent_state = AgentState(harness=Harness(evolver=evolver))
 
     try:
         tasks = adapter.list_tasks()

--- a/clawloop/environments/__init__.py
+++ b/clawloop/environments/__init__.py
@@ -8,10 +8,19 @@ from clawloop.environments.enterpriseops_gym import (
     build_adapter_from_hf,
 )
 
+
+def __getattr__(name: str):
+    if name == "TauBenchAdapter":
+        from clawloop.environments.taubench import TauBenchAdapter
+        return TauBenchAdapter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "EnvAdapter",
     "HarborAdapter",
     "HarborTaskEnvironment",
+    "TauBenchAdapter",
     "EnterpriseOpsGymAdapter",
     "EnterpriseOpsGymEnvironment",
     "build_adapter_from_hf",

--- a/clawloop/environments/taubench.py
+++ b/clawloop/environments/taubench.py
@@ -1,0 +1,353 @@
+"""TauBench (tau3) adapter — integrates sierra-research/tau2-bench (dev/tau3 branch)
+into the ClawLoop learning loop.
+
+Supports retail and airline domains (and any other tau2-registered domain).
+tau2 is used as a Python library — no subprocess or external server required.
+
+Install tau2:
+    pip install "clawloop[taubench]"
+    # or directly:
+    pip install git+https://github.com/sierra-research/tau2-bench.git@dev/tau3
+"""
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from clawloop.core.episode import Episode, EpisodeSummary, Message, StepMeta
+from clawloop.environments.base import EnvAdapter
+
+if TYPE_CHECKING:
+    from clawloop.core.loop import AgentState
+
+log = logging.getLogger(__name__)
+
+_AGENT_KEY = "clawloop_agent"
+
+# Module-level names imported lazily — set to None here so tests can patch them
+# without tau2 installed. _require_tau2() raises if they are still None at runtime.
+try:
+    from tau2.run import get_tasks, run_single_task
+    from tau2.data_model.simulation import TextRunConfig
+    from tau2.evaluator.evaluator import EvaluationType
+except ImportError:
+    get_tasks = None          # type: ignore[assignment]
+    run_single_task = None    # type: ignore[assignment]
+    TextRunConfig = None      # type: ignore[assignment]
+    EvaluationType = None     # type: ignore[assignment]
+
+
+def _require_tau2() -> None:
+    if get_tasks is None:
+        raise ImportError(
+            "tau2 is required for TauBenchAdapter. "
+            'Install: pip install "clawloop[taubench]" or '
+            "pip install git+https://github.com/sierra-research/tau2-bench.git@dev/tau3"
+        )
+
+
+class TauBenchAdapter(EnvAdapter):
+    """EnvAdapter for tau-bench 3 (sierra-research/tau2-bench, dev/tau3 branch).
+
+    Supports retail and airline domains. Set ``domain`` in the config dict to
+    switch between them. Any other tau2-registered domain also works.
+
+    Example config::
+
+        {
+            "domain": "retail",
+            "llm_agent": "openai/claude-haiku-4-5-20251001",
+            "llm_user": "openai/claude-haiku-4-5-20251001",
+            "max_steps": 30,
+            "max_concurrency": 8,
+            "task_split": "test",
+            "num_tasks": 10
+        }
+    """
+
+    def setup(self, config: dict[str, Any]) -> None:
+        """One-time initialization from config dict."""
+        self._domain = config.get("domain", "retail")
+        self._llm_agent = config.get("llm_agent", "openai/gpt-4o-mini")
+        self._llm_user = config.get("llm_user", "openai/gpt-4o-mini")
+        self._max_steps = int(config.get("max_steps", 30))
+        self._max_concurrency = int(config.get("max_concurrency", 8))
+        self._task_split = config.get("task_split", "test")
+        self._num_tasks = config.get("num_tasks", None)
+        self._config = config
+        self._iteration_count = 0
+
+    def list_tasks(self, split: str = "test") -> list[str]:
+        """Return available task IDs for the configured domain and split."""
+        _require_tau2()
+        tasks = get_tasks(task_set_name=self._domain, task_split_name=split)
+        return [t.id for t in tasks]
+
+    def run_episode(self, task: Any, agent_state: "AgentState") -> Episode:
+        """Run a single task. Delegates to run_batch."""
+        episodes = self.run_batch(agent_state, [task])
+        return episodes[0]
+
+    def run_batch(
+        self, agent_state: "AgentState", task_ids: list[Any]
+    ) -> list[Episode]:
+        """Run a batch of tasks in parallel via ThreadPoolExecutor.
+
+        Registers a ClawLoopAgent with the current harness prompt in tau2's
+        registry before execution, so the evolved system prompt is injected
+        for every task in this batch.
+        """
+        _require_tau2()
+
+        # Pull current harness prompt
+        harness_prompt = ""
+        if hasattr(agent_state, "harness") and agent_state.harness:
+            try:
+                harness_prompt = agent_state.harness.system_prompt("taubench")
+            except Exception:
+                log.debug("Failed to get harness system prompt", exc_info=True)
+
+        # Register custom agent with current harness instruction
+        _register_clawloop_agent(harness_prompt)
+
+        # Load tau2 Task objects for the requested IDs
+        all_tasks = get_tasks(
+            task_set_name=self._domain, task_split_name=self._task_split
+        )
+        task_map = {t.id: t for t in all_tasks}
+
+        config = TextRunConfig(
+            domain=self._domain,
+            agent=_AGENT_KEY,
+            user="user_simulator",
+            llm_agent=self._llm_agent,
+            llm_args_agent={},
+            llm_user=self._llm_user,
+            llm_args_user={},
+            max_steps=self._max_steps,
+        )
+
+        state_id = ""
+        if hasattr(agent_state, "state_id") and callable(agent_state.state_id):
+            try:
+                state_id = agent_state.state_id().combined_hash
+            except Exception:
+                log.debug("Failed to compute state_id", exc_info=True)
+
+        str_ids = [str(tid) for tid in task_ids]
+
+        def _run_one(task_id: str) -> Episode:
+            task = task_map.get(task_id)
+            if task is None:
+                log.warning(
+                    "Task %r not found in domain %r split %r",
+                    task_id, self._domain, self._task_split,
+                )
+                return self._make_failed_episode(task_id, state_id, "task_not_found")
+            try:
+                # ALL_IGNORE_BASIS: use DB check + action checks as ground
+                # truth; skip NL assertion evaluation (requires separate LLM
+                # judge config). DB state verification is the primary signal.
+                sim_run = run_single_task(
+                    config, task,
+                    evaluation_type=EvaluationType.ALL_IGNORE_BASIS,
+                )
+                return self._map_to_episode(sim_run, task_id, state_id)
+            except Exception as exc:
+                log.error("tau2 run_single_task failed for %s: %s", task_id, exc)
+                return self._make_failed_episode(task_id, state_id, type(exc).__name__)
+
+        with ThreadPoolExecutor(max_workers=self._max_concurrency) as pool:
+            futures = [pool.submit(_run_one, tid) for tid in str_ids]
+            # Preserve submission order. _run_one catches all exceptions internally
+            # so f.result() always returns an Episode (never raises).
+            episodes = [f.result() for f in futures]
+
+        self._iteration_count += 1
+        return episodes
+
+    def _map_to_episode(
+        self, sim_run: Any, task_id: str, state_id: str
+    ) -> Episode:
+        """Convert a tau2 SimulationRun to a ClawLoop Episode."""
+        # Convert tau2 messages to ClawLoop Messages
+        messages: list[Message] = []
+        for m in sim_run.messages or []:
+            role = getattr(m, "role", "user")
+            role_str = role.value if hasattr(role, "value") else str(role)
+            content = getattr(m, "content", "")
+            if not isinstance(content, str):
+                content = ""  # tool messages; flatten to empty string
+            messages.append(Message(role=role_str, content=content))
+
+        step_boundaries = _compute_step_boundaries(messages)
+
+        reward_info = sim_run.reward_info
+        summary = EpisodeSummary()
+
+        if reward_info is not None:
+            summary.total_reward = float(reward_info.reward)
+            breakdown: dict[str, Any] = {"reward": reward_info.reward}
+            if reward_info.db_check is not None:
+                breakdown["db_check"] = reward_info.db_check.model_dump()
+            if reward_info.env_assertions:
+                breakdown["env_assertions"] = [
+                    a.model_dump() for a in reward_info.env_assertions
+                ]
+            if reward_info.action_checks:
+                breakdown["action_checks"] = [
+                    a.model_dump() for a in reward_info.action_checks
+                ]
+            summary.score_breakdown = breakdown
+        else:
+            summary.total_reward = 0.0
+
+        term = getattr(sim_run, "termination_reason", None)
+        term_str = term.value if hasattr(term, "value") else str(term) if term else ""
+        # MAX_ERRORS_REACHED means the episode is invalid — filter it from training
+        summary.filtered = term_str == "MAX_ERRORS_REACHED"
+
+        duration_ms = getattr(sim_run, "duration", 0.0) * 1000
+        reward_val = float(reward_info.reward) if reward_info is not None else 0.0
+        steps = [StepMeta(t=0, reward=reward_val, done=True, timing_ms=duration_ms)]
+
+        return Episode(
+            id=uuid4().hex,
+            state_id=state_id,
+            task_id=f"taubench:{task_id}",
+            bench="taubench",
+            messages=messages,
+            step_boundaries=step_boundaries,
+            steps=steps,
+            summary=summary,
+            metadata={
+                "domain": self._domain,
+                "termination_reason": term_str,
+                "agent_cost": getattr(sim_run, "agent_cost", None),
+                "user_cost": getattr(sim_run, "user_cost", None),
+                "truncated": term_str == "MAX_STEPS_REACHED",
+            },
+        )
+
+    def _make_failed_episode(
+        self, task_id: str, state_id: str, reason: str
+    ) -> Episode:
+        """Return a negative-reward episode for tasks that could not be run (missing task, exception, etc.).
+
+        The episode is kept unfiltered so the agent receives a -1.0 outcome signal as a
+        training gradient. Only structural failures (MAX_ERRORS_REACHED) are filtered via
+        summary.filtered in _map_to_episode.
+        """
+        from clawloop.core.reward import RewardSignal
+
+        summary = EpisodeSummary(
+            signals={"outcome": RewardSignal(name="outcome", value=-1.0, confidence=0.5)}
+        )
+        return Episode(
+            id=uuid4().hex,
+            state_id=state_id,
+            task_id=f"taubench:{task_id}",
+            bench="taubench",
+            messages=[],
+            step_boundaries=[],
+            steps=[],
+            summary=summary,
+            metadata={"error": reason, "domain": self._domain},
+        )
+
+    def get_traces(self, episode: Episode) -> dict[str, Any]:
+        return {"bench": "taubench", "episode_id": episode.id, "domain": self._domain}
+
+
+# ---------------------------------------------------------------------------
+# ClawLoop harness injection
+# ---------------------------------------------------------------------------
+
+# Default instruction used when no harness prompt is configured.
+_DEFAULT_HARNESS_INSTRUCTION: str = (
+    "You are a customer service agent. Help the user according to the policy. "
+    "Be accurate, efficient, and polite."
+)
+
+# Module-level mutable cell: updated before each batch so _ClawLoopAgent
+# reads the latest harness prompt at property-access time, without needing
+# a new class definition per iteration.
+# Thread-safety note: ClawLoop's learning loop calls run_batch() sequentially
+# (one batch per iteration). Concurrent run_batch() calls with different harness
+# prompts are NOT supported — they would race on this cell.
+_current_harness_instruction: str = _DEFAULT_HARNESS_INSTRUCTION
+
+# Lazily-created agent class and factory (defined once, reused every iteration).
+_clawloop_agent_class: type | None = None
+_clawloop_factory: Any = None
+
+
+def _register_clawloop_agent(harness_instruction: str) -> None:
+    """Register a ClawLoopAgent factory in tau2's registry.
+
+    Updates the module-level prompt cell and (lazily) defines the agent class
+    once. Re-registration across iterations just overwrites the registry slot —
+    no new class is created per call.
+    """
+    global _current_harness_instruction, _clawloop_agent_class, _clawloop_factory
+    # Use explicit default rather than "or" so an empty string clears the stale
+    # prompt instead of leaking the previous batch's instruction.
+    _current_harness_instruction = harness_instruction or _DEFAULT_HARNESS_INSTRUCTION
+
+    if _clawloop_agent_class is None:
+        from tau2.agent.llm_agent import LLMAgent, SYSTEM_PROMPT
+
+        class _ClawLoopAgent(LLMAgent):
+            @property
+            def system_prompt(self) -> str:  # type: ignore[override]
+                return SYSTEM_PROMPT.format(
+                    agent_instruction=_current_harness_instruction,
+                    domain_policy=self.domain_policy,
+                )
+
+        def _factory(
+            tools: Any,
+            domain_policy: str,
+            llm: str | None = None,
+            llm_args: dict | None = None,
+            **_: Any,
+        ) -> _ClawLoopAgent:
+            return _ClawLoopAgent(
+                tools=tools,
+                domain_policy=domain_policy,
+                llm=llm or "gpt-4o-mini",
+                llm_args=llm_args or {},
+            )
+
+        _clawloop_agent_class = _ClawLoopAgent
+        _clawloop_factory = _factory
+
+    from tau2.registry import registry
+    # Write directly to the private dict to support re-registration across
+    # learning iterations. tau2's public register_agent_factory() raises
+    # ValueError on duplicate names (tau2/registry.py ~L129) with no
+    # overwrite=True option. Track https://github.com/sierra-research/tau2-bench
+    # for a future public API that supports upsert.
+    registry._agent_factories[_AGENT_KEY] = _clawloop_factory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _compute_step_boundaries(messages: list[Message]) -> list[int]:
+    """Return indices of messages that start a new conversation step.
+
+    A step starts at each user message that immediately follows a non-user
+    message (or at the very first message). Consecutive user messages are
+    treated as a single turn.
+    """
+    boundaries: list[int] = []
+    for i, msg in enumerate(messages):
+        if msg.role == "user" and (i == 0 or messages[i - 1].role != "user"):
+            boundaries.append(i)
+    if not boundaries and messages:
+        boundaries = [0]
+    return boundaries

--- a/clawloop/learning_layers/harness.py
+++ b/clawloop/learning_layers/harness.py
@@ -424,6 +424,16 @@ class Harness:
     # Max entries returned in full-playbook fallback
     _max_retrieval_entries: int = 50
 
+    _REMOVED_ATTRS: frozenset[str] = frozenset({"reflector"})
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name in self._REMOVED_ATTRS:
+            raise AttributeError(
+                f"'Harness.{name}' was removed. "
+                f"Use Harness(evolver=LocalEvolver({name}=...)) instead."
+            )
+        super().__setattr__(name, value)
+
     def system_prompt(
         self,
         bench: str,
@@ -586,6 +596,10 @@ class Harness:
                         result.action, result.entries_affected,
                     )
                     if result.action != "skip_redundant":
+                        # Stamp generation on newly created entries so the
+                        # auto-prune patience window is correct.
+                        if result.new_entry is not None and result.new_entry.generation == 0:
+                            result.new_entry.generation = self.playbook_generation
                         structural_change = True
                         applied += 1
                 else:
@@ -594,6 +608,7 @@ class Harness:
                         content=insight.content,
                         tags=insight.tags,
                         source_episode_ids=list(insight.source_episode_ids),
+                        generation=self.playbook_generation,
                     )
                     self.playbook.add(entry)
                     structural_change = True
@@ -659,10 +674,19 @@ class Harness:
                     log.warning("Dropping insight — source_episode_ids must be list[str]")
                     continue
 
-            # Tag character whitelist
+            # Tag character whitelist — sanitize rather than drop the insight.
+            # LLMs often produce tags with spaces or punctuation; normalise them
+            # (lowercase, spaces→underscores, strip remaining invalid chars).
             if any(not _TAG_RE.match(t) for t in insight.tags if t):
-                log.warning("Dropping insight — tags contain invalid characters")
-                continue
+                cleaned = []
+                for t in insight.tags:
+                    t = re.sub(r"\s+", "_", t.lower().strip())
+                    t = re.sub(r"[^a-zA-Z0-9\-_]", "", t)
+                    if t:
+                        cleaned.append(t)
+                insight = insight.__class__(
+                    **{**insight.__dict__, "tags": cleaned}
+                )
 
             # Content length
             if len(insight.content) > _MAX_INSIGHT_CONTENT_LENGTH:
@@ -959,12 +983,33 @@ class Harness:
                         entry.decay_rate = max(entry.decay_rate, deprecation_decay)
                         updates += 1
 
-            # Auto-prune entries with sustained negative score
-            # Only prune entries that have enough signal (helpful+harmful >= 3)
+            # Auto-prune entries with sustained strongly-negative score.
+            #
+            # Thresholds (informed by ACE's more conservative approach):
+            #   min_generations = 3  — entry must survive at least 3 learning
+            #                          iterations (playbook_generation advances on
+            #                          each structural change) before it is eligible
+            #                          for pruning; this prevents churn in weak-model
+            #                          regimes where everything fails regardless of
+            #                          playbook content
+            #   score < -3           — require 3+ more harmful than helpful signals,
+            #                          not just any negative score
+            #
+            # Note: "harmful" = episode failed AND entry was attributed to it
+            # (tag match, embedding match, or all-entries fallback).  With the
+            # fallback active, all entries are penalised by every failed episode,
+            # so the score threshold matters more than the generation guard.
+            #
+            # ACE never auto-prunes (LLM issues explicit REMOVE). We keep
+            # auto-prune as a safety valve but make it patient.
+            _PRUNE_MIN_GENERATIONS = 3
+            _PRUNE_MIN_SCORE = -3
             before_prune = len(self.playbook.entries)
+            current_gen = self.playbook_generation
             self.playbook.entries = [
                 e for e in self.playbook.entries
-                if e.score() >= 0.0 or (e.helpful + e.harmful) < 3
+                if e.score() >= _PRUNE_MIN_SCORE
+                or (current_gen - e.generation) < _PRUNE_MIN_GENERATIONS
             ]
             pruned = before_prune - len(self.playbook.entries)
             if pruned:

--- a/clawloop/train.py
+++ b/clawloop/train.py
@@ -240,17 +240,20 @@ def train(config: TrainConfig):
 
     layers = validate_config(config)
 
-    # 1. Harness — always created; reflector wired only if harness is active
+    # 1. Harness — reflector wired via LocalEvolver when harness layer is active
     prompts = {b: config.system_prompt for b in config.benches}
     # Auto-register env_type as prompt key so harness.sample(bench=env_type) works
     prompts.setdefault(config.env_type, config.system_prompt)
-    harness = Harness(system_prompts=prompts)
 
+    evolver = None
     if "harness" in layers:
         from clawloop.core.reflector import Reflector
+        from clawloop.harness_backends.local import LocalEvolver
 
         reflector_client = _make_llm_client(config.llm_clients["reflector"])
-        harness.reflector = Reflector(client=reflector_client)
+        evolver = LocalEvolver(reflector=Reflector(client=reflector_client))
+
+    harness = Harness(system_prompts=prompts, evolver=evolver)
 
     # 2. Weights backend
     backend = None

--- a/examples/configs/taubench_harness.json
+++ b/examples/configs/taubench_harness.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "TauBench harness learning config. Set domain to retail or airline.",
+  "domain": "retail",
+  "llm_agent": "gemini/gemini-2.0-flash-lite",
+  "llm_user": "gemini/gemini-2.0-flash-lite",
+  "max_steps": 30,
+  "max_concurrency": 8,
+  "task_split": "test",
+  "num_tasks": 10
+}

--- a/examples/recipes/a2a_crmarena.py
+++ b/examples/recipes/a2a_crmarena.py
@@ -41,22 +41,20 @@ def run_harness_learning(args):
     from clawloop.environments.entropic import EntropicAdapter
     from clawloop.core.intensity import AdaptiveIntensity
     from clawloop.core.loop import AgentState, learning_loop
-    from clawloop.core.reflector import Reflector
     from clawloop.learning_layers.harness import Harness
     from clawloop.learning_layers.router import Router
     from clawloop.learning_layers.weights import Weights
-    from clawloop.llm import LiteLLMClient
+    from examples.recipes.common import build_local_evolver
 
-    harness = Harness(system_prompts={
-        "entropic": (
-            "You are a CRM assistant. Help users with service requests accurately. "
-            "Verify information before making changes. Handle schema drift gracefully."
-        ),
-    })
-    if args.reflector_model:
-        harness.reflector = Reflector(client=LiteLLMClient(
-            model=args.reflector_model, api_key=args.api_key, api_base=args.api_base,
-        ))
+    harness = Harness(
+        system_prompts={
+            "entropic": (
+                "You are a CRM assistant. Help users with service requests accurately. "
+                "Verify information before making changes. Handle schema drift gracefully."
+            ),
+        },
+        evolver=build_local_evolver(args.reflector_model, args.api_key, args.api_base),
+    )
 
     adapter = EntropicAdapter()
     adapter.setup({

--- a/examples/recipes/arithmetic.py
+++ b/examples/recipes/arithmetic.py
@@ -41,20 +41,20 @@ def run_harness_learning(args):
     from clawloop.core.episode import Episode, EpisodeSummary, Message, StepMeta
     from clawloop.core.intensity import AdaptiveIntensity
     from clawloop.core.loop import AgentState, learning_loop
-    from clawloop.core.reflector import Reflector
     from clawloop.core.reward import RewardSignal
     from clawloop.core.types import SampleContext
     from clawloop.learning_layers.harness import Harness
     from clawloop.learning_layers.router import Router
     from clawloop.learning_layers.weights import Weights
     from clawloop.llm import LiteLLMClient
+    from examples.recipes.common import build_local_evolver
 
-    harness = Harness(system_prompts={
-        "arithmetic": "Solve arithmetic problems step by step. Put your final answer in \\boxed{} notation.",
-    })
-    harness.reflector = Reflector(client=LiteLLMClient(
-        model=args.reflector_model, api_key=args.api_key, api_base=args.api_base,
-    ))
+    harness = Harness(
+        system_prompts={
+            "arithmetic": "Solve arithmetic problems step by step. Put your final answer in \\boxed{} notation.",
+        },
+        evolver=build_local_evolver(args.reflector_model, args.api_key, args.api_base),
+    )
     task_client = LiteLLMClient(model=args.task_model, api_key=args.api_key, api_base=args.api_base)
 
     problems = [(random.randint(1, 100), random.randint(1, 100)) for _ in range(200)]

--- a/examples/recipes/common.py
+++ b/examples/recipes/common.py
@@ -1,0 +1,32 @@
+"""Shared helpers for ClawLoop benchmark recipes."""
+from __future__ import annotations
+
+
+def build_local_evolver(
+    reflector_model: str | None,
+    api_key: str = "",
+    api_base: str | None = None,
+    reflection_batch_size: int = 1,
+) -> "LocalEvolver":
+    """Build a LocalEvolver with an optional Reflector.
+
+    Use this in every recipe instead of constructing Reflector and LocalEvolver
+    inline, to ensure the wiring stays correct as the API evolves.
+    """
+    from clawloop.harness_backends.local import LocalEvolver
+
+    reflector = None
+    if reflector_model:
+        from clawloop.core.reflector import Reflector, ReflectorConfig
+        from clawloop.llm import LiteLLMClient
+
+        reflector = Reflector(
+            client=LiteLLMClient(
+                model=reflector_model,
+                api_key=api_key,
+                api_base=api_base,
+            ),
+            config=ReflectorConfig(reflection_batch_size=reflection_batch_size),
+        )
+
+    return LocalEvolver(reflector=reflector)

--- a/examples/recipes/guess_number.py
+++ b/examples/recipes/guess_number.py
@@ -201,18 +201,17 @@ def main():
     log.info("mode=%s layers=%s", args.mode, layers)
 
     # 1. Harness
-    harness = Harness(system_prompts={
-        "guess_number": (
-            "You are playing a number guessing game. Use binary search strategy. "
-            f"The number is between 0 and {MAX_VAL}. Reply with just your guess."
-        ),
-    })
-    if "harness" in layers:
-        from clawloop.core.reflector import Reflector
-        from clawloop.llm import LiteLLMClient
-        harness.reflector = Reflector(client=LiteLLMClient(
-            model=args.reflector_model, api_key=args.api_key, api_base=args.api_base,
-        ))
+    from examples.recipes.common import build_local_evolver
+    harness = Harness(
+        system_prompts={
+            "guess_number": (
+                "You are playing a number guessing game. Use binary search strategy. "
+                f"The number is between 0 and {MAX_VAL}. Reply with just your guess."
+            ),
+        },
+        evolver=build_local_evolver(args.reflector_model, args.api_key, args.api_base)
+        if "harness" in layers else None,
+    )
 
     # 2. Weights — SkyRL backend (Tinker-compatible)
     backend = None

--- a/examples/recipes/harbor_bfcl.py
+++ b/examples/recipes/harbor_bfcl.py
@@ -42,12 +42,11 @@ def run_harness_learning(args):
 
     from clawloop.core.intensity import AdaptiveIntensity
     from clawloop.core.loop import AgentState, learning_loop
-    from clawloop.core.reflector import Reflector
     from clawloop.environments.harbor import HarborAdapter, HarborTaskEnvironment
     from clawloop.learning_layers.harness import Harness
     from clawloop.learning_layers.router import Router
     from clawloop.learning_layers.weights import Weights
-    from clawloop.llm import LiteLLMClient
+    from examples.recipes.common import build_local_evolver
 
     task_dirs = _find_task_dirs(args.task_dir)
     if not task_dirs:
@@ -55,16 +54,16 @@ def run_harness_learning(args):
         sys.exit(1)
     log.info("Found %d Harbor tasks in %s", len(task_dirs), args.task_dir)
 
-    harness = Harness(system_prompts={
-        "harbor": (
-            "You are a function-calling assistant. When given a function schema "
-            "and a natural language request, write the correct JSON function call. "
-            "Write your result to /app/result.json as a JSON array."
-        ),
-    })
-    harness.reflector = Reflector(client=LiteLLMClient(
-        model=args.reflector_model, api_key=args.api_key, api_base=args.api_base,
-    ))
+    harness = Harness(
+        system_prompts={
+            "harbor": (
+                "You are a function-calling assistant. When given a function schema "
+                "and a natural language request, write the correct JSON function call. "
+                "Write your result to /app/result.json as a JSON array."
+            ),
+        },
+        evolver=build_local_evolver(args.reflector_model, args.api_key, args.api_base),
+    )
 
     trial_config = {
         "agent": {

--- a/examples/recipes/taubench.py
+++ b/examples/recipes/taubench.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""ClawLoop recipe: tau-bench 3 harness learning.
+
+Runs harness learning on tau-bench retail or airline tasks. The ClawLoop
+Harness layer evolves the agent system prompt based on per-episode reward
+signals from tau-bench's domain-specific verifier.
+
+Requirements:
+    pip install "clawloop[taubench]"
+    export OPENAI_API_KEY=...   # or ANTHROPIC_API_KEY, etc.
+
+Usage (retail, 3 tasks, 3 iterations — quick smoke test):
+    python examples/recipes/taubench.py \\
+        --domain retail \\
+        --task-ids retail_0 retail_1 retail_2 \\
+        --iterations 3
+
+Usage (airline, 5 tasks, 5 iterations):
+    python examples/recipes/taubench.py \\
+        --domain airline \\
+        --task-ids airline_0 airline_1 airline_2 airline_3 airline_4 \\
+        --iterations 5
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+log = logging.getLogger("clawloop.recipe.taubench")
+
+_RETAIL_SYSTEM_PROMPT = (
+    "You are a retail customer service agent. Help users with orders, returns, "
+    "and product questions. Follow the policy exactly. Be concise and accurate."
+)
+
+_AIRLINE_SYSTEM_PROMPT = (
+    "You are an airline customer service agent. Help users with flight bookings, "
+    "cancellations, and seat upgrades. Follow the policy exactly. Be concise and accurate."
+)
+
+_DOMAIN_PROMPTS: dict[str, str] = {
+    "retail": _RETAIL_SYSTEM_PROMPT,
+    "airline": _AIRLINE_SYSTEM_PROMPT,
+}
+
+
+def run_harness_learning(args: argparse.Namespace) -> None:
+    from clawloop.environments.taubench import TauBenchAdapter
+    from clawloop.core.intensity import AdaptiveIntensity
+    from clawloop.core.loop import AgentState, learning_loop
+    from clawloop.learning_layers.harness import Harness
+    from clawloop.learning_layers.router import Router
+    from clawloop.learning_layers.weights import Weights
+
+    from examples.recipes.common import build_local_evolver
+
+    starter_prompt = _DOMAIN_PROMPTS.get(args.domain, _RETAIL_SYSTEM_PROMPT)
+
+    harness = Harness(
+        system_prompts={"taubench": starter_prompt},
+        evolver=build_local_evolver(
+            reflector_model=args.reflector_model,
+            api_key=args.api_key,
+            api_base=args.api_base,
+            reflection_batch_size=args.reflection_batch_size,
+        ),
+    )
+
+    adapter = TauBenchAdapter()
+    adapter.setup(
+        {
+            "domain": args.domain,
+            "llm_agent": args.task_model,
+            "llm_user": args.task_model,
+            "max_steps": args.max_steps,
+            "max_concurrency": args.max_concurrency,
+            "task_split": args.task_split,
+        }
+    )
+
+    # Resolve task IDs: explicit list or auto-discover from split
+    if args.task_ids:
+        tasks = args.task_ids
+    else:
+        tasks = adapter.list_tasks(args.task_split)[: args.num_tasks]
+        log.info("Auto-discovered %d tasks from split %r", len(tasks), args.task_split)
+
+    agent_state = AgentState(harness=harness, router=Router(), weights=Weights())
+
+    log.info(
+        "Starting harness learning: domain=%s tasks=%d iterations=%d",
+        args.domain, len(tasks), args.iterations,
+    )
+
+    agent_state, state_id = learning_loop(
+        adapter=adapter,
+        agent_state=agent_state,
+        tasks=tasks,
+        n_episodes=len(tasks),
+        n_iterations=args.iterations,
+        active_layers=["harness", "router"],
+        intensity=AdaptiveIntensity(reflect_every_n=args.reflect_every),
+    )
+
+    print(f"\nDone. State: {state_id.combined_hash[:12]}")
+    print(f"Domain: {args.domain} | Iterations: {args.iterations} | Tasks: {len(tasks)}")
+
+    if harness.playbook and harness.playbook.entries:
+        print(f"\nPlaybook entries after learning: {len(harness.playbook.entries)}")
+        for entry in harness.playbook.entries[:5]:
+            print(f"  - {entry.content[:100]}")
+    else:
+        print("\nNo playbook entries yet (may need more iterations or failures to trigger learning).")
+
+    print(f"\nFinal system prompt (first 300 chars):")
+    print(harness.system_prompt("taubench")[:300])
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="ClawLoop tau-bench 3 harness learning recipe")
+    p.add_argument("--domain", choices=["retail", "airline"], default="retail",
+                   help="tau-bench domain to run")
+    p.add_argument("--task-ids", nargs="*", default=None,
+                   help="Explicit task IDs to run (e.g. retail_0 retail_1). "
+                        "If omitted, auto-discovers from --task-split up to --num-tasks.")
+    p.add_argument("--num-tasks", type=int, default=5,
+                   help="Number of tasks to auto-discover when --task-ids is not set")
+    p.add_argument("--task-split", default="test",
+                   help="tau-bench split to use (test, dev, train)")
+    p.add_argument("--iterations", type=int, default=3,
+                   help="Number of harness learning iterations")
+    p.add_argument("--max-steps", type=int, default=30,
+                   help="Max conversation steps per episode")
+    p.add_argument("--max-concurrency", type=int, default=4,
+                   help="Max parallel episodes per batch")
+    p.add_argument("--task-model", default="gemini/gemini-2.0-flash-lite",
+                   help="Model for agent and user simulator (default: gemini-2.0-flash-lite)")
+    p.add_argument("--reflector-model", default="gemini/gemini-2.5-flash-lite",
+                   help="Model for the ClawLoop reflector — runs once per iteration "
+                        "(default: gemini-2.5-flash-lite)")
+    p.add_argument("--reflect-every", type=int, default=1,
+                   help="Reflect every N iterations (1=every iteration, 3=default adaptive)")
+    p.add_argument("--reflection-batch-size", type=int, default=4,
+                   help="Episodes per Reflector LLM call — higher enables contrastive learning")
+    p.add_argument("--api-base", default=os.environ.get("CLAWLOOP_API_BASE"),
+                   help="API base URL override (e.g. for local proxy)")
+    p.add_argument("--api-key", default=os.environ.get("CLAWLOOP_API_KEY", ""),
+                   help="API key override")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    log.info("domain=%s model=%s iterations=%d", args.domain, args.task_model, args.iterations)
+
+    run_harness_learning(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ server = [
     "uvicorn>=0.20",
     "httpx>=0.24",
 ]
+taubench = [
+    "tau2 @ git+https://github.com/sierra-research/tau2-bench.git@dev/tau3",
+]
 [project.scripts]
 clawloop = "clawloop.cli:main"
 clawloop-server = "clawloop.server:main"
@@ -56,6 +59,10 @@ Repository = "https://github.com/aganthos/clawloop"
 Issues = "https://github.com/aganthos/clawloop/issues"
 Documentation = "https://aganthos.github.io/clawloop"
 Website = "https://aganthos.com"
+
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/tests/test_harness_reflector.py
+++ b/tests/test_harness_reflector.py
@@ -132,3 +132,11 @@ class TestHarnessReflector:
         prompt = h.system_prompt("math")
         assert "Solve problems carefully." in prompt
         assert "verify input format" in prompt
+
+
+def test_harness_reflector_setattr_raises():
+    """Harness.__setattr__ guard must catch the old dead-slot pattern."""
+    import pytest
+    h = Harness()
+    with pytest.raises(AttributeError, match="reflector.*removed"):
+        h.reflector = object()

--- a/tests/test_harness_signals.py
+++ b/tests/test_harness_signals.py
@@ -98,10 +98,11 @@ class TestInsightValidation:
         result = Harness._validate_insights([insight])
         assert len(result) == 1
 
-    def test_rejects_invalid_tag_chars(self) -> None:
+    def test_sanitizes_invalid_tag_chars(self) -> None:
         insight = Insight(action="add", content="tip", tags=["good-tag", "bad tag!"])
         result = Harness._validate_insights([insight])
-        assert len(result) == 0
+        assert len(result) == 1
+        assert result[0].tags == ["good-tag", "bad_tag"]
 
     def test_accepts_valid_tags(self) -> None:
         insight = Insight(

--- a/tests/test_taubench_adapter.py
+++ b/tests/test_taubench_adapter.py
@@ -1,0 +1,315 @@
+"""Unit tests for TauBenchAdapter — tau2 library is mocked throughout."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, PropertyMock
+import pytest
+
+from clawloop.core.episode import Message
+from clawloop.environments.taubench import TauBenchAdapter, _compute_step_boundaries
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tau2_message(role: str, content: str):
+    m = MagicMock()
+    m.role = MagicMock()
+    m.role.value = role
+    m.content = content
+    return m
+
+
+def _make_sim_run(
+    reward: float = 1.0,
+    messages=None,
+    termination_reason: str = "SUCCESS",
+    duration: float = 1.5,
+):
+    sim_run = MagicMock()
+    sim_run.reward_info = MagicMock()
+    sim_run.reward_info.reward = reward
+    sim_run.reward_info.db_check = None
+    sim_run.reward_info.env_assertions = []
+    sim_run.reward_info.action_checks = []
+    sim_run.messages = messages or []
+    tr = MagicMock()
+    tr.value = termination_reason
+    sim_run.termination_reason = tr
+    sim_run.duration = duration
+    sim_run.agent_cost = 0.01
+    sim_run.user_cost = 0.005
+    return sim_run
+
+
+def _make_task(task_id: str):
+    t = MagicMock()
+    t.id = task_id
+    return t
+
+
+def _make_agent_state(harness_prompt: str = "You are helpful."):
+    state = MagicMock()
+    state.harness.system_prompt.return_value = harness_prompt
+    state.state_id.return_value.combined_hash = "abc123"
+    return state
+
+
+# ---------------------------------------------------------------------------
+# _compute_step_boundaries
+# ---------------------------------------------------------------------------
+
+class TestComputeStepBoundaries:
+    def test_empty_returns_empty(self):
+        assert _compute_step_boundaries([]) == []
+
+    def test_single_user_message(self):
+        msgs = [Message(role="user", content="hi")]
+        assert _compute_step_boundaries(msgs) == [0]
+
+    def test_user_assistant_user(self):
+        msgs = [
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="hello"),
+            Message(role="user", content="bye"),
+        ]
+        assert _compute_step_boundaries(msgs) == [0, 2]
+
+    def test_consecutive_user_messages_count_as_one_boundary(self):
+        msgs = [
+            Message(role="user", content="a"),
+            Message(role="user", content="b"),
+            Message(role="assistant", content="c"),
+            Message(role="user", content="d"),
+        ]
+        assert _compute_step_boundaries(msgs) == [0, 3]
+
+    def test_only_assistant_messages_returns_zero(self):
+        msgs = [Message(role="assistant", content="a")]
+        assert _compute_step_boundaries(msgs) == [0]
+
+
+# ---------------------------------------------------------------------------
+# TauBenchAdapter._map_to_episode
+# ---------------------------------------------------------------------------
+
+class TestMapToEpisode:
+    def _adapter(self, domain: str = "retail") -> TauBenchAdapter:
+        a = TauBenchAdapter()
+        a._domain = domain
+        a._iteration_count = 0
+        return a
+
+    def test_successful_episode_has_outcome_signal(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run(reward=1.0)
+        ep = adapter._map_to_episode(sim_run, "retail_0", "abc123")
+        assert ep.task_id == "taubench:retail_0"
+        assert ep.bench == "taubench"
+        # total_reward=1.0 maps to outcome signal value=1.0
+        assert ep.summary.signals["outcome"].value == pytest.approx(1.0)
+
+    def test_failed_episode_outcome_zero(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run(reward=0.0)
+        ep = adapter._map_to_episode(sim_run, "retail_1", "abc123")
+        assert ep.summary.signals["outcome"].value == pytest.approx(-1.0)
+
+    def test_messages_are_mapped(self):
+        adapter = self._adapter()
+        tau_messages = [
+            _make_tau2_message("user", "Hello"),
+            _make_tau2_message("assistant", "Hi there"),
+        ]
+        sim_run = _make_sim_run(messages=tau_messages)
+        ep = adapter._map_to_episode(sim_run, "retail_0", "abc123")
+        assert len(ep.messages) == 2
+        assert ep.messages[0].role == "user"
+        assert ep.messages[0].content == "Hello"
+        assert ep.messages[1].role == "assistant"
+
+    def test_score_breakdown_contains_reward(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run(reward=1.0)
+        ep = adapter._map_to_episode(sim_run, "retail_0", "state42")
+        assert ep.summary.score_breakdown["reward"] == pytest.approx(1.0)
+
+    def test_state_id_propagated(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run()
+        ep = adapter._map_to_episode(sim_run, "retail_0", "mystate")
+        assert ep.state_id == "mystate"
+
+    def test_max_steps_metadata_set(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run(termination_reason="MAX_STEPS_REACHED")
+        ep = adapter._map_to_episode(sim_run, "retail_0", "")
+        assert ep.metadata.get("truncated") is True
+
+    def test_reward_info_none_gives_zero_reward(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run()
+        sim_run.reward_info = None
+        ep = adapter._map_to_episode(sim_run, "retail_0", "")
+        assert ep.summary.signals["outcome"].value == pytest.approx(-1.0)
+
+    def test_db_check_in_score_breakdown(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run(reward=1.0)
+        db_check = MagicMock()
+        db_check.model_dump.return_value = {"passed": True}
+        sim_run.reward_info.db_check = db_check
+        ep = adapter._map_to_episode(sim_run, "retail_0", "")
+        assert ep.summary.score_breakdown["db_check"] == {"passed": True}
+
+    def test_domain_in_metadata(self):
+        adapter = self._adapter("airline")
+        sim_run = _make_sim_run()
+        ep = adapter._map_to_episode(sim_run, "airline_0", "")
+        assert ep.metadata["domain"] == "airline"
+
+    def test_max_errors_reached_sets_filtered(self):
+        adapter = self._adapter()
+        sim_run = _make_sim_run(termination_reason="MAX_ERRORS_REACHED")
+        ep = adapter._map_to_episode(sim_run, "retail_0", "")
+        assert ep.summary.filtered is True
+
+
+# ---------------------------------------------------------------------------
+# TauBenchAdapter._make_failed_episode
+# ---------------------------------------------------------------------------
+
+class TestMakeFailedEpisode:
+    def test_failed_episode_has_negative_outcome(self):
+        adapter = TauBenchAdapter()
+        adapter._domain = "retail"
+        ep = adapter._make_failed_episode("retail_0", "state1", "task_not_found")
+        assert ep.summary.signals["outcome"].value == pytest.approx(-1.0)
+        assert ep.metadata["error"] == "task_not_found"
+        assert ep.task_id == "taubench:retail_0"
+
+
+# ---------------------------------------------------------------------------
+# TauBenchAdapter.list_tasks
+# ---------------------------------------------------------------------------
+
+class TestListTasks:
+    @patch("clawloop.environments.taubench.get_tasks")
+    def test_returns_task_ids(self, mock_get_tasks):
+        mock_get_tasks.return_value = [_make_task("retail_0"), _make_task("retail_1")]
+        adapter = TauBenchAdapter()
+        adapter._domain = "retail"
+        result = adapter.list_tasks("test")
+        assert result == ["retail_0", "retail_1"]
+        mock_get_tasks.assert_called_once_with(task_set_name="retail", task_split_name="test")
+
+
+# ---------------------------------------------------------------------------
+# TauBenchAdapter.run_batch
+# ---------------------------------------------------------------------------
+
+class TestRunBatch:
+    @patch("clawloop.environments.taubench.run_single_task")
+    @patch("clawloop.environments.taubench.get_tasks")
+    @patch("clawloop.environments.taubench._register_clawloop_agent")
+    @patch("clawloop.environments.taubench.TextRunConfig")
+    def test_run_batch_returns_one_episode_per_task(
+        self, mock_config, mock_register, mock_get_tasks, mock_run_single
+    ):
+        mock_get_tasks.return_value = [_make_task("retail_0"), _make_task("retail_1")]
+        mock_run_single.return_value = _make_sim_run(reward=1.0)
+
+        adapter = TauBenchAdapter()
+        adapter._domain = "retail"
+        adapter._llm_agent = "openai/gpt-4o-mini"
+        adapter._llm_user = "openai/gpt-4o-mini"
+        adapter._max_steps = 30
+        adapter._max_concurrency = 2
+        adapter._task_split = "test"
+        adapter._iteration_count = 0
+
+        agent_state = _make_agent_state()
+        episodes = adapter.run_batch(agent_state, ["retail_0", "retail_1"])
+
+        assert len(episodes) == 2
+        assert all(ep.bench == "taubench" for ep in episodes)
+        mock_register.assert_called_once()
+
+    @patch("clawloop.environments.taubench.run_single_task")
+    @patch("clawloop.environments.taubench.get_tasks")
+    @patch("clawloop.environments.taubench._register_clawloop_agent")
+    @patch("clawloop.environments.taubench.TextRunConfig")
+    def test_missing_task_produces_failed_episode(
+        self, mock_config, mock_register, mock_get_tasks, mock_run_single
+    ):
+        mock_get_tasks.return_value = [_make_task("retail_0")]  # retail_99 not here
+
+        adapter = TauBenchAdapter()
+        adapter._domain = "retail"
+        adapter._llm_agent = "openai/gpt-4o-mini"
+        adapter._llm_user = "openai/gpt-4o-mini"
+        adapter._max_steps = 30
+        adapter._max_concurrency = 2
+        adapter._task_split = "test"
+        adapter._iteration_count = 0
+
+        agent_state = _make_agent_state()
+        episodes = adapter.run_batch(agent_state, ["retail_99"])
+
+        assert len(episodes) == 1
+        assert episodes[0].metadata["error"] == "task_not_found"
+
+
+
+# ---------------------------------------------------------------------------
+# TauBenchAdapter.setup
+# ---------------------------------------------------------------------------
+
+class TestSetup:
+    def test_setup_reads_config(self):
+        adapter = TauBenchAdapter()
+        adapter.setup({
+            "domain": "airline",
+            "llm_agent": "openai/gpt-4o",
+            "llm_user": "openai/gpt-4o",
+            "max_steps": 50,
+            "max_concurrency": 4,
+            "task_split": "dev",
+            "num_tasks": 5,
+        })
+        assert adapter._domain == "airline"
+        assert adapter._llm_agent == "openai/gpt-4o"
+        assert adapter._max_steps == 50
+        assert adapter._max_concurrency == 4
+        assert adapter._task_split == "dev"
+        assert adapter._num_tasks == 5
+        assert adapter._iteration_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Harness prompt passthrough
+# ---------------------------------------------------------------------------
+
+class TestHarnessPromptPassthrough:
+    @patch("clawloop.environments.taubench.TextRunConfig")
+    @patch("clawloop.environments.taubench._register_clawloop_agent")
+    @patch("clawloop.environments.taubench.get_tasks")
+    @patch("clawloop.environments.taubench.run_single_task")
+    def test_harness_prompt_passed_to_register(
+        self, mock_run, mock_get_tasks, mock_register, mock_config
+    ):
+        """Confirm the current harness prompt is forwarded to _register_clawloop_agent."""
+        from clawloop.core.loop import AgentState
+        from clawloop.learning_layers.harness import Harness
+
+        mock_get_tasks.return_value = [_make_task("retail_0")]
+        mock_run.return_value = _make_sim_run(reward=1.0)
+
+        harness = Harness(system_prompts={"taubench": "Follow the policy carefully."})
+        agent_state = AgentState(harness=harness)
+
+        adapter = TauBenchAdapter()
+        adapter.setup({"domain": "retail", "task_split": "test"})
+        adapter.run_batch(agent_state, ["retail_0"])
+
+        mock_register.assert_called_once_with("Follow the policy carefully.")


### PR DESCRIPTION
## Summary

- Adds `TauBenchAdapter` — a ClawLoop `EnvAdapter` for tau-bench 3 (sierra-research/tau2-bench, dev/tau3 branch), supporting retail and airline domains out of the box
- Fixes a systemic silent bug: `harness.reflector = Reflector(...)` was silently dropped across 7 files (cli, train, and all recipes) because `Harness` has no `reflector` field — only `evolver`. The Reflector was never firing. Fixed by wiring `evolver=LocalEvolver(reflector=...)` everywhere and adding a `Harness.__setattr__` guard that raises `AttributeError` with a migration message
- Adds `examples/recipes/common.py` with `build_local_evolver()` — shared helper used by all recipes to avoid inline construction drift
- Generation-based playbook auto-prune (waits ≥3 iterations of low score before pruning, not signal count)
- Lazy import: `TauBenchAdapter` in `environments/__init__.py` uses `__getattr__` so tau2 (heavy optional dep) is never imported unless explicitly used

## What's new in the adapter

- `run_batch`: parallel execution via `ThreadPoolExecutor`, preserves submission order
- `_register_clawloop_agent`: lazily defines `_ClawLoopAgent` once (module-level cache), updates a shared prompt cell before each batch so the evolved harness prompt is injected without redefining the class per iteration
- `_map_to_episode`: maps tau2 `SimulationRun` → ClawLoop `Episode` with reward breakdown, termination reason, and `filtered=True` for `MAX_ERRORS_REACHED` episodes
- `pyproject.toml` taubench extra: `pip install "clawloop[taubench]"`
- Recipe: `examples/recipes/taubench.py` — runnable end-to-end harness learning on retail/airline with Gemini Flash models

## Test plan

- [ ] `pytest tests/unit/environments/test_taubench.py -v` — unit tests (tau2 mocked)
- [ ] `python examples/recipes/taubench.py --domain retail --task-ids retail_0 retail_1 retail_2 --iterations 2` — smoke test (requires tau2 + Gemini API key)
- [ ] Verify no tau2 import on `from clawloop.environments import HarborAdapter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)