### PR TITLE
feat: preserve reasoning_content through trajectory ingest

### DIFF
--- a/clawloop/collector.py
+++ b/clawloop/collector.py
@@ -183,13 +183,23 @@ class EpisodeCollector:
             # Attach response_logprobs at construction (no post-mutation)
             if i == last_assistant_idx and response_logprobs and not msg_logprobs:
                 msg_logprobs = parse_logprobs(response_logprobs)
-            # Reasoning model fallback: if content is None but reasoning
-            # exists (Qwen3, DeepSeek-R1, OpenAI o1/o3), use reasoning.
-            # Use explicit None check — empty string "" is a valid content
-            # (e.g. tool-call-only responses).
+            # Reasoning normalization: canonical field is reasoning_content
+            # (OpenAI o-series, Qwen3, Z.AI/GLM). Legacy alias: reasoning
+            # (Ollama, our own parse_sse_bytes). Prefer canonical, but fall
+            # back to legacy if canonical is absent or explicitly None.
+            raw_reasoning = m.get("reasoning_content")
+            if raw_reasoning is None:
+                raw_reasoning = m.get("reasoning")
+
             msg_content = m.get("content")
-            if msg_content is None:
-                msg_content = m.get("reasoning") or m.get("reasoning_content") or ""
+            if msg_content is None and m.get("role") == "assistant":
+                # Back-compat: reasoning-only assistant turns still surface
+                # in content so existing dashboards / exporters see non-empty
+                # strings. Canonical reasoning also in reasoning_content.
+                msg_content = raw_reasoning if raw_reasoning is not None else ""
+            elif msg_content is None:
+                msg_content = ""
+
             ep_messages.append(
                 Message(
                     role=m.get("role", "user"),
@@ -199,6 +209,7 @@ class EpisodeCollector:
                     tool_call_id=m.get("tool_call_id"),
                     model=m.get("model"),
                     logprobs=msg_logprobs,
+                    reasoning_content=raw_reasoning,
                 )
             )
 

--- a/clawloop/core/episode.py
+++ b/clawloop/core/episode.py
@@ -71,6 +71,7 @@ class Message:
     token_count: int | None = None
     model: str | None = None  # which model generated this
     logprobs: list[TokenLogProb] | None = None  # per-token log probs from generation
+    reasoning_content: str | None = None  # thinking / CoT from reasoning models
 
     def to_openai_dict(self) -> dict[str, Any]:
         """Serialize to the dict format expected by OpenAI-compatible APIs."""

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -329,3 +329,165 @@ class TestIngestExternal:
         )
         assert "execution" in ep.summary.signals
         assert ep.summary.signals["execution"].value < 0
+
+
+class TestReasoningContentIngestion:
+    """Reasoning normalization at the collector boundary."""
+
+    def _collector(self):
+        return EpisodeCollector(pipeline=RewardPipeline([]), batch_size=100)
+
+    def test_preserves_canonical_reasoning_content_key(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "final",
+             "reasoning_content": "step-by-step thinking"},
+        ])
+        asst = ep.messages[-1]
+        assert asst.content == "final"
+        assert asst.reasoning_content == "step-by-step thinking"
+
+    def test_normalizes_legacy_reasoning_key(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "final", "reasoning": "legacy"},
+        ])
+        assert ep.messages[-1].reasoning_content == "legacy"
+
+    def test_empty_content_falls_back_to_reasoning_for_compat(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None, "reasoning_content": "T"},
+        ])
+        asst = ep.messages[-1]
+        assert asst.content == "T"
+        assert asst.reasoning_content == "T"
+
+    def test_both_content_and_reasoning_preserved_independently(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "final",
+             "reasoning_content": "thinking"},
+        ])
+        asst = ep.messages[-1]
+        assert asst.content == "final"
+        assert asst.reasoning_content == "thinking"
+
+    def test_empty_string_reasoning_preserved_not_coerced(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "x", "reasoning_content": ""},
+        ])
+        assert ep.messages[-1].reasoning_content == ""
+
+    def test_canonical_key_wins_over_legacy_when_both_present(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "x",
+             "reasoning_content": "canonical", "reasoning": "legacy"},
+        ])
+        assert ep.messages[-1].reasoning_content == "canonical"
+
+    def test_no_reasoning_keys_leaves_field_none(self):
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "x"},
+        ])
+        assert ep.messages[-1].reasoning_content is None
+
+    def test_canonical_none_falls_back_to_legacy(self):
+        """When reasoning_content is explicitly None, fall back to the
+        legacy reasoning key if it has a non-None value."""
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "x",
+             "reasoning_content": None, "reasoning": "from-legacy"},
+        ])
+        assert ep.messages[-1].reasoning_content == "from-legacy"
+
+    def test_content_fallback_only_for_assistant_role(self):
+        """Reasoning-into-content fallback is assistant-only. A malformed
+        non-assistant message with content=None doesn't get reasoning
+        injected into content."""
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": None, "reasoning": "leak"},
+            {"role": "assistant", "content": "ok"},
+        ])
+        assert ep.messages[0].content == ""
+        assert ep.messages[0].reasoning_content == "leak"
+
+
+class TestReasoningContentE2E:
+    """Integration: SSE parser → collector → Message. Covers the real
+    regression boundary for reasoning preservation end-to-end."""
+
+    def _collector(self):
+        return EpisodeCollector(pipeline=RewardPipeline([]), batch_size=100)
+
+    def test_sse_stream_with_reasoning_content_key(self):
+        """OpenAI-style stream using reasoning_content delta key."""
+        from clawloop.proxy_sse import parse_sse_bytes
+
+        sse = (
+            b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"reasoning_content":"let me think"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"reasoning_content":" carefully"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"42"}}]}\n\n'
+            b'data: [DONE]\n\n'
+        )
+        msg, _usage, complete = parse_sse_bytes(sse)
+        assert complete
+        assert msg is not None
+
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "q"},
+            msg,
+        ])
+        asst = ep.messages[-1]
+        assert asst.content == "42"
+        assert asst.reasoning_content == "let me think carefully"
+
+    def test_sse_stream_with_ollama_reasoning_key(self):
+        """Ollama-style stream using legacy reasoning delta key."""
+        from clawloop.proxy_sse import parse_sse_bytes
+
+        sse = (
+            b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"reasoning":"ollama thinking"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"ans"}}]}\n\n'
+            b'data: [DONE]\n\n'
+        )
+        msg, _usage, _ = parse_sse_bytes(sse)
+        assert msg is not None
+
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "q"},
+            msg,
+        ])
+        asst = ep.messages[-1]
+        assert asst.content == "ans"
+        assert asst.reasoning_content == "ollama thinking"
+
+    def test_sse_reasoning_only_turn_back_compat(self):
+        """When the SSE stream has reasoning but no content (thinking-only
+        turn), the parser inlines reasoning into content. The collector
+        should also set reasoning_content on the Message."""
+        from clawloop.proxy_sse import parse_sse_bytes
+
+        sse = (
+            b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"reasoning_content":"deep thought"}}]}\n\n'
+            b'data: [DONE]\n\n'
+        )
+        msg, _, _ = parse_sse_bytes(sse)
+        assert msg is not None
+        # Parser inlines reasoning into content when content is empty
+        assert msg["content"] == "deep thought"
+
+        ep = self._collector().ingest_external([
+            {"role": "user", "content": "q"},
+            msg,
+        ])
+        asst = ep.messages[-1]
+        assert asst.content == "deep thought"
+        assert asst.reasoning_content == "deep thought"

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -282,3 +282,45 @@ class TestMessageLogprobs:
         msg = Message(role="assistant", content="hi", logprobs=lps)
         d = msg.to_openai_dict()
         assert "logprobs" not in d
+
+
+class TestMessageReasoningContent:
+    def test_default_is_none(self) -> None:
+        msg = Message(role="assistant", content="hi")
+        assert msg.reasoning_content is None
+
+    def test_stored_alongside_content(self) -> None:
+        msg = Message(
+            role="assistant",
+            content="final answer",
+            reasoning_content="step by step thinking",
+        )
+        assert msg.content == "final answer"
+        assert msg.reasoning_content == "step by step thinking"
+
+    def test_empty_string_preserved(self) -> None:
+        msg = Message(role="assistant", content="x", reasoning_content="")
+        assert msg.reasoning_content == ""
+
+    def test_not_in_openai_dict(self) -> None:
+        """to_openai_dict() is the OpenAI Chat Completions request shape.
+        reasoning_content is an internal record field — must not be emitted.
+        """
+        msg = Message(
+            role="assistant", content="x", reasoning_content="y"
+        )
+        d = msg.to_openai_dict()
+        assert "reasoning_content" not in d
+        assert "reasoning" not in d
+        assert d == {"role": "assistant", "content": "x"}
+
+    def test_openai_dict_roundtrip_is_lossy(self) -> None:
+        """Document the contract: Message -> to_openai_dict -> Message loses
+        reasoning_content. Future maintainers must not assume lossless
+        round-trips through the OpenAI wire format."""
+        original = Message(
+            role="assistant", content="x", reasoning_content="y"
+        )
+        d = original.to_openai_dict()
+        reconstructed = Message(role=d["role"], content=d["content"])
+        assert reconstructed.reasoning_content is None


### PR DESCRIPTION
## Summary

- Adds `Message.reasoning_content: str | None = None` so trajectories from reasoning-capable models (Qwen3, DeepSeek-R1, OpenAI o1/o3, GLM/Z.AI, Ollama) retain the thinking/answer split
- Normalizes inbound `reasoning_content` (canonical, OpenAI) and `reasoning` (legacy, Ollama) at a single boundary: `collector.ingest_external`
- Back-compat preserved: reasoning-only assistant turns still surface in `content` AND `reasoning_content`

## Motivation

Cross-family SFT — e.g. exporting GLM trajectories for Qwen fine-tuning — requires the ChatML skeleton to distinguish reasoning tokens from answer tokens. ClawLoop's SSE parser already captured reasoning at parse time, but the `Message` dataclass had no field for it. Reasoning was either inlined into `content` (lossy merge) or attached to a raw dict key that nothing consumed.

## What changes

- `core/episode.py`: one additive field on `Message`
- `collector.py`: explicit key-presence normalization with null-precedence fallback and assistant-only content gate
- 17 new tests: field behavior (5), collector normalization (9), E2E parser→collector (3)

## What does NOT change

- `Message.to_openai_dict()` stays strict (OpenAI Chat Completions request shape only)
- `proxy_sse.parse_sse_bytes` is untouched — continues emitting legacy `reasoning` key; collector normalizes
- SkyRL exporter training behavior unchanged — reasoning loss-masking is a follow-up
- Client-facing SSE tee untouched

## Verification

- Archive: not present in public repo (enterprise-only); additive field with default `None` is forward-compatible
- StateID hashing: hashes layer params (harness/router/weights), not Messages — unaffected
- Content hash: N/A in public repo
- 977 tests pass, 35 skipped, 0 failures
- Secrets + monorepo-leak audits clean

## Follow-ups (separate PRs)

- SkyRL exporter: tokenize `reasoning_content` into response with `loss_mask=1` behind a flag
- Canonical SFT JSONL exporter with chat-template-aware reasoning rendering
- `Episode.to_openai_messages()` is lossy (drops `reasoning_content`) — a full-fidelity export method may be needed

## Review history

- Codex spec review: 2 rounds → SHIP IT
- Codex code review: 1 round → NEEDS WORK (null-precedence bug, role-gate, lossy-roundtrip test) → all fixed
- Self-review: SHIP IT

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>