### PR TITLE
feat: public evolution archive protocol and JsonlArchiveStore

### DIFF
--- a/clawloop/__init__.py
+++ b/clawloop/__init__.py
@@ -3,6 +3,15 @@
 __version__ = "0.0.1"
 
 from clawloop.agent import ClawLoopAgent
+from clawloop.archive import (
+    AgentVariant,
+    ArchiveStore,
+    EpisodeRecord,
+    IterationRecord,
+    JsonlArchiveStore,
+    NullArchiveStore,
+    RunRecord,
+)
 from clawloop.callbacks.litellm_cb import ClawLoopCallback
 from clawloop.collector import EpisodeCollector
 from clawloop.completion import CompletionResult
@@ -15,17 +24,24 @@ from clawloop.llm import LiteLLMClient, MockLLMClient
 from clawloop.wrapper import wrap
 
 __all__ = [
+    "AgentVariant",
+    "ArchiveStore",
     "AsyncLearner",
-    "CompletionResult",
-    "EpisodeCollector",
-    "EvalResult",
     "ClawLoopAgent",
     "ClawLoopCallback",
+    "CompletionResult",
+    "EpisodeCollector",
+    "EpisodeRecord",
+    "EvalResult",
+    "IterationRecord",
+    "JsonlArchiveStore",
     "LiteLLMClient",
     "LocalEvolver",
     "MockLLMClient",
+    "NullArchiveStore",
     "RewardPipeline",
     "RewardSignal",
+    "RunRecord",
     "Sample",
     "StaticTaskEnvironment",
     "TokenLogProb",

--- a/clawloop/archive/__init__.py
+++ b/clawloop/archive/__init__.py
@@ -1,0 +1,26 @@
+"""Evolution Archive — structured data capture for learning runs.
+
+Public surface: ``ArchiveStore`` protocol, ``JsonlArchiveStore``,
+``NullArchiveStore``, and the 4 schema dataclasses. Indexed SQLite/Postgres
+stores, Parquet export, and curation tooling live in the enterprise package.
+"""
+
+from clawloop.archive.jsonl_store import JsonlArchiveStore
+from clawloop.archive.null_store import NullArchiveStore
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+from clawloop.archive.store import ArchiveStore
+
+__all__ = [
+    "AgentVariant",
+    "ArchiveStore",
+    "EpisodeRecord",
+    "IterationRecord",
+    "JsonlArchiveStore",
+    "NullArchiveStore",
+    "RunRecord",
+]

--- a/clawloop/archive/jsonl_store.py
+++ b/clawloop/archive/jsonl_store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -44,6 +45,8 @@ def _write_line(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "a", encoding="utf-8") as f:
         f.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
 
 
 class JsonlArchiveStore:
@@ -120,6 +123,8 @@ class JsonlArchiveStore:
         with self._lock:
             with open(path, "a", encoding="utf-8") as f:
                 f.write("\n".join(lines) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
 
     def log_variant(self, variant: AgentVariant) -> None:
         payload = {
@@ -155,9 +160,9 @@ class JsonlArchiveStore:
     # Linear scans. Intentional: the public store optimizes for safe,
     # simple writes. Indexed queries live in enterprise SqliteArchiveStore.
     #
-    # Note on concurrency: reads hold the same mutex as writes to avoid
-    # racing with an in-flight append. This is fine for local debugging
-    # workloads; busy producers should prefer the enterprise SQLite store.
+    # Reads are lock-free: the store is append-only, so readers see a
+    # consistent prefix on POSIX. Partial tail lines from concurrent
+    # writes are caught by the JSONDecodeError handler.
     # ------------------------------------------------------------------
 
     def get_run(self, run_id: str) -> RunRecord | None:
@@ -167,7 +172,7 @@ class JsonlArchiveStore:
 
         best: dict | None = None
         completion: dict | None = None
-        with self._lock, open(path, encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 try:
                     rec = json.loads(line)
@@ -218,7 +223,7 @@ class JsonlArchiveStore:
         tag_set = set(domain_tags)
         starts: dict[str, dict] = {}
         completions: dict[str, dict] = {}
-        with self._lock, open(path, encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 try:
                     rec = json.loads(line)

--- a/clawloop/archive/jsonl_store.py
+++ b/clawloop/archive/jsonl_store.py
@@ -1,0 +1,275 @@
+"""JsonlArchiveStore — append-only JSONL archive for local use.
+
+Zero-dependency public implementation. Every call appends a single JSON line
+tagged with ``record_type`` so the file is a self-describing stream.
+
+Query/index capabilities live in the enterprise ``SqliteArchiveStore``;
+this store is intentionally write-optimized and scan-only for reads.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+
+log = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 1
+
+
+def _safe_run_id(run_id: str) -> str:
+    """Reject run_id values that could escape the archive directory."""
+    if (
+        not run_id
+        or "/" in run_id
+        or "\\" in run_id
+        or ".." in run_id
+        or run_id.startswith(".")
+    ):
+        raise ValueError(f"unsafe run_id for filesystem path: {run_id!r}")
+    return run_id
+
+
+def _write_line(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, separators=(",", ":")) + "\n")
+
+
+class JsonlArchiveStore:
+    """Append-only JSONL archive. One line per record, tagged by type."""
+
+    def __init__(self, archive_dir: str | Path = "~/.clawloop/archive") -> None:
+        self._archive_dir = Path(archive_dir).expanduser().resolve()
+        self._archive_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._archive_dir.chmod(0o700)
+        except OSError:
+            pass
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Paths
+    # ------------------------------------------------------------------
+
+    def _runs_path(self) -> Path:
+        return self._archive_dir / "runs.jsonl"
+
+    def _iterations_path(self) -> Path:
+        return self._archive_dir / "iterations.jsonl"
+
+    def _variants_path(self) -> Path:
+        return self._archive_dir / "variants.jsonl"
+
+    def _episodes_path(self, run_id: str) -> Path:
+        return self._archive_dir / _safe_run_id(run_id) / "episodes.jsonl"
+
+    # ------------------------------------------------------------------
+    # Write operations (ArchiveStore protocol)
+    # ------------------------------------------------------------------
+
+    def log_run_start(self, run: RunRecord) -> None:
+        payload = {
+            "_schema": _SCHEMA_VERSION,
+            "record_type": "run_start",
+            **run.to_dict(),
+        }
+        with self._lock:
+            _write_line(self._runs_path(), payload)
+
+    def log_iteration(self, iteration: IterationRecord) -> None:
+        payload = {
+            "_schema": _SCHEMA_VERSION,
+            "record_type": "iteration",
+            **iteration.to_dict(),
+        }
+        with self._lock:
+            _write_line(self._iterations_path(), payload)
+
+    def log_episodes(self, episodes: list[EpisodeRecord]) -> None:
+        if not episodes:
+            return
+        run_id = _safe_run_id(episodes[0].run_id)
+        # Enforce homogeneous batch: store routes files by run_id. Mixing
+        # run_ids in one call would silently land them under the first's dir.
+        for ep in episodes[1:]:
+            if ep.run_id != run_id:
+                raise ValueError(
+                    "log_episodes batches must share a run_id; "
+                    f"got {run_id!r} and {ep.run_id!r}"
+                )
+        path = self._episodes_path(run_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            json.dumps(
+                {"_schema": _SCHEMA_VERSION, "record_type": "episode", **ep.to_dict()},
+                separators=(",", ":"),
+            )
+            for ep in episodes
+        ]
+        with self._lock:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+
+    def log_variant(self, variant: AgentVariant) -> None:
+        payload = {
+            "_schema": _SCHEMA_VERSION,
+            "record_type": "variant",
+            **variant.to_dict(),
+        }
+        with self._lock:
+            _write_line(self._variants_path(), payload)
+
+    def log_run_complete(
+        self,
+        run_id: str,
+        best_reward: float,
+        improvement_delta: float,
+        total_cost_tokens: int = 0,
+    ) -> None:
+        payload = {
+            "_schema": _SCHEMA_VERSION,
+            "record_type": "run_complete",
+            "run_id": run_id,
+            "best_reward": best_reward,
+            "improvement_delta": improvement_delta,
+            "total_cost_tokens": total_cost_tokens,
+            "completed_at": time.time(),
+        }
+        with self._lock:
+            _write_line(self._runs_path(), payload)
+
+    # ------------------------------------------------------------------
+    # Read operations
+    #
+    # Linear scans. Intentional: the public store optimizes for safe,
+    # simple writes. Indexed queries live in enterprise SqliteArchiveStore.
+    #
+    # Note on concurrency: reads hold the same mutex as writes to avoid
+    # racing with an in-flight append. This is fine for local debugging
+    # workloads; busy producers should prefer the enterprise SQLite store.
+    # ------------------------------------------------------------------
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        path = self._runs_path()
+        if not path.exists():
+            return None
+
+        best: dict | None = None
+        completion: dict | None = None
+        with self._lock, open(path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("run_id") != run_id:
+                    continue
+                rtype = rec.get("record_type")
+                if rtype == "run_start":
+                    best = rec
+                elif rtype == "run_complete":
+                    completion = rec
+
+        if best is None:
+            return None
+
+        if completion is not None:
+            best = {
+                **best,
+                "best_reward": completion.get("best_reward", best.get("best_reward", 0.0)),
+                "improvement_delta": completion.get(
+                    "improvement_delta", best.get("improvement_delta", 0.0)
+                ),
+                "total_cost_tokens": completion.get(
+                    "total_cost_tokens", best.get("total_cost_tokens", 0)
+                ),
+                "completed_at": completion.get("completed_at"),
+            }
+        best.pop("_schema", None)
+        best.pop("record_type", None)
+        return RunRecord.from_dict(best)
+
+    def get_similar_runs(
+        self,
+        config_hash: str,
+        domain_tags: list[str],
+        limit: int = 10,
+    ) -> list[RunRecord]:
+        """Linear scan, returns matches ordered by best_reward desc.
+
+        OR semantics: a run matches if its ``config_hash`` equals the query
+        OR any of its ``domain_tags`` is in the query set.
+        """
+        path = self._runs_path()
+        if not path.exists():
+            return []
+
+        tag_set = set(domain_tags)
+        starts: dict[str, dict] = {}
+        completions: dict[str, dict] = {}
+        with self._lock, open(path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                run_id = rec.get("run_id")
+                if not run_id:
+                    continue
+                rtype = rec.get("record_type")
+                if rtype == "run_start":
+                    starts[run_id] = rec
+                elif rtype == "run_complete":
+                    completions[run_id] = rec
+
+        merged: list[RunRecord] = []
+        for run_id, start in starts.items():
+            if start.get("config_hash") != config_hash and not (
+                tag_set and tag_set.intersection(start.get("domain_tags", []))
+            ):
+                continue
+            completion = completions.get(run_id)
+            if completion is not None:
+                start = {
+                    **start,
+                    "best_reward": completion.get(
+                        "best_reward", start.get("best_reward", 0.0)
+                    ),
+                    "improvement_delta": completion.get(
+                        "improvement_delta", start.get("improvement_delta", 0.0)
+                    ),
+                    "total_cost_tokens": completion.get(
+                        "total_cost_tokens", start.get("total_cost_tokens", 0)
+                    ),
+                    "completed_at": completion.get("completed_at"),
+                }
+            start.pop("_schema", None)
+            start.pop("record_type", None)
+            merged.append(RunRecord.from_dict(start))
+
+        merged.sort(key=lambda r: r.best_reward, reverse=True)
+        return merged[:limit]
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """No-op: files are opened-and-closed per write for crash safety."""
+
+    def __enter__(self) -> JsonlArchiveStore:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/clawloop/archive/null_store.py
+++ b/clawloop/archive/null_store.py
@@ -1,0 +1,43 @@
+"""NullArchiveStore — no-op implementation for when archiving is disabled."""
+
+from __future__ import annotations
+
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+
+
+class NullArchiveStore:
+    """Drop-in archive store that silently discards all data."""
+
+    def log_run_start(self, run: RunRecord) -> None:
+        pass
+
+    def log_iteration(self, iteration: IterationRecord) -> None:
+        pass
+
+    def log_episodes(self, episodes: list[EpisodeRecord]) -> None:
+        pass
+
+    def log_variant(self, variant: AgentVariant) -> None:
+        pass
+
+    def log_run_complete(
+        self, run_id: str, best_reward: float, improvement_delta: float,
+        total_cost_tokens: int = 0,
+    ) -> None:
+        pass
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        return None
+
+    def get_similar_runs(
+        self,
+        config_hash: str,
+        domain_tags: list[str],
+        limit: int = 10,
+    ) -> list[RunRecord]:
+        return []

--- a/clawloop/archive/schema.py
+++ b/clawloop/archive/schema.py
@@ -1,0 +1,204 @@
+"""Dataclass schema for evolution archive records."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class RunRecord:
+    """Top-level record for one evolution run."""
+
+    run_id: str
+    bench: str
+    domain_tags: list[str]
+    agent_config: dict[str, Any]
+    config_hash: str
+    n_iterations: int
+    best_reward: float
+    improvement_delta: float
+    total_cost_tokens: int
+    parent_run_id: str | None
+    created_at: float
+    completed_at: float | None
+
+    @staticmethod
+    def new_id() -> str:
+        """Generate a fresh run ID."""
+        return uuid.uuid4().hex
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "bench": self.bench,
+            "domain_tags": self.domain_tags,
+            "agent_config": self.agent_config,
+            "config_hash": self.config_hash,
+            "n_iterations": self.n_iterations,
+            "best_reward": self.best_reward,
+            "improvement_delta": self.improvement_delta,
+            "total_cost_tokens": self.total_cost_tokens,
+            "parent_run_id": self.parent_run_id,
+            "created_at": self.created_at,
+            "completed_at": self.completed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RunRecord:
+        return cls(
+            run_id=d["run_id"],
+            bench=d["bench"],
+            domain_tags=d["domain_tags"],
+            agent_config=d["agent_config"],
+            config_hash=d["config_hash"],
+            n_iterations=d["n_iterations"],
+            best_reward=d["best_reward"],
+            improvement_delta=d["improvement_delta"],
+            total_cost_tokens=d["total_cost_tokens"],
+            parent_run_id=d.get("parent_run_id"),
+            created_at=d["created_at"],
+            completed_at=d.get("completed_at"),
+        )
+
+
+@dataclass
+class IterationRecord:
+    """One iteration within an evolution run."""
+
+    run_id: str
+    iteration_num: int
+    harness_snapshot_hash: str
+    mean_reward: float
+    reward_trajectory: list[float]
+    evolver_action: dict[str, Any]
+    cost_tokens: int
+    parent_variant_hash: str | None
+    child_variant_hash: str | None
+    reward_delta: float
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "iteration_num": self.iteration_num,
+            "harness_snapshot_hash": self.harness_snapshot_hash,
+            "mean_reward": self.mean_reward,
+            "reward_trajectory": self.reward_trajectory,
+            "evolver_action": self.evolver_action,
+            "cost_tokens": self.cost_tokens,
+            "parent_variant_hash": self.parent_variant_hash,
+            "child_variant_hash": self.child_variant_hash,
+            "reward_delta": self.reward_delta,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> IterationRecord:
+        return cls(
+            run_id=d["run_id"],
+            iteration_num=d["iteration_num"],
+            harness_snapshot_hash=d["harness_snapshot_hash"],
+            mean_reward=d["mean_reward"],
+            reward_trajectory=d["reward_trajectory"],
+            evolver_action=d["evolver_action"],
+            cost_tokens=d["cost_tokens"],
+            parent_variant_hash=d.get("parent_variant_hash"),
+            child_variant_hash=d.get("child_variant_hash"),
+            reward_delta=d["reward_delta"],
+            created_at=d["created_at"],
+        )
+
+
+@dataclass
+class EpisodeRecord:
+    """One episode (single task execution) within an iteration."""
+
+    run_id: str
+    iteration_num: int
+    episode_id: str
+    task_id: str
+    bench: str
+    model: str
+    reward: float
+    signals: dict[str, Any]
+    n_steps: int
+    n_tool_calls: int
+    token_usage: dict[str, Any]
+    latency_ms: int
+    messages_ref: str
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "iteration_num": self.iteration_num,
+            "episode_id": self.episode_id,
+            "task_id": self.task_id,
+            "bench": self.bench,
+            "model": self.model,
+            "reward": self.reward,
+            "signals": self.signals,
+            "n_steps": self.n_steps,
+            "n_tool_calls": self.n_tool_calls,
+            "token_usage": self.token_usage,
+            "latency_ms": self.latency_ms,
+            "messages_ref": self.messages_ref,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> EpisodeRecord:
+        return cls(
+            run_id=d["run_id"],
+            iteration_num=d["iteration_num"],
+            episode_id=d["episode_id"],
+            task_id=d["task_id"],
+            bench=d["bench"],
+            model=d["model"],
+            reward=d["reward"],
+            signals=d["signals"],
+            n_steps=d["n_steps"],
+            n_tool_calls=d["n_tool_calls"],
+            token_usage=d["token_usage"],
+            latency_ms=d["latency_ms"],
+            messages_ref=d["messages_ref"],
+            created_at=d["created_at"],
+        )
+
+
+@dataclass
+class AgentVariant:
+    """Content-addressed snapshot of a specific agent configuration."""
+
+    variant_hash: str
+    system_prompt: str
+    playbook_snapshot: dict[str, Any]
+    model: str
+    tools: list[str]
+    first_seen_run_id: str
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "variant_hash": self.variant_hash,
+            "system_prompt": self.system_prompt,
+            "playbook_snapshot": self.playbook_snapshot,
+            "model": self.model,
+            "tools": self.tools,
+            "first_seen_run_id": self.first_seen_run_id,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AgentVariant:
+        return cls(
+            variant_hash=d["variant_hash"],
+            system_prompt=d["system_prompt"],
+            playbook_snapshot=d["playbook_snapshot"],
+            model=d["model"],
+            tools=d["tools"],
+            first_seen_run_id=d["first_seen_run_id"],
+            created_at=d["created_at"],
+        )

--- a/clawloop/archive/store.py
+++ b/clawloop/archive/store.py
@@ -1,0 +1,38 @@
+"""ArchiveStore protocol — interface for evolution archive backends."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+
+
+class ArchiveStore(Protocol):
+    """Backend-agnostic interface for persisting evolution archive data."""
+
+    def log_run_start(self, run: RunRecord) -> None: ...
+
+    def log_iteration(self, iteration: IterationRecord) -> None: ...
+
+    def log_episodes(self, episodes: list[EpisodeRecord]) -> None: ...
+
+    def log_variant(self, variant: AgentVariant) -> None: ...
+
+    def log_run_complete(
+        self, run_id: str, best_reward: float, improvement_delta: float,
+        total_cost_tokens: int = 0,
+    ) -> None: ...
+
+    def get_run(self, run_id: str) -> RunRecord | None: ...
+
+    def get_similar_runs(
+        self,
+        config_hash: str,
+        domain_tags: list[str],
+        limit: int = 10,
+    ) -> list[RunRecord]: ...

--- a/clawloop/core/loop.py
+++ b/clawloop/core/loop.py
@@ -17,6 +17,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Protocol
 
+from clawloop.archive.null_store import NullArchiveStore
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+from clawloop.archive.store import ArchiveStore
 from clawloop.core.episode import Episode
 from clawloop.core.evolution_log import EvolutionEntry, EvolutionLog
 from clawloop.core.intensity import AdaptiveIntensity
@@ -25,6 +33,7 @@ from clawloop.core.types import Datum, FBResult, Future, OptimResult
 from clawloop.learning_layers.harness import Harness
 from clawloop.learning_layers.router import Router
 from clawloop.learning_layers.weights import Weights
+from clawloop.utils.content_hash import canonical_hash
 
 log = logging.getLogger(__name__)
 
@@ -134,6 +143,16 @@ class AdapterLike(Protocol):
     def run_episode(self, task: Any, agent_state: AgentState) -> Episode: ...
 
 
+def _build_agent_config(agent_state: AgentState) -> dict[str, Any]:
+    """Extract serializable agent config snapshot for archive identity."""
+    config: dict[str, Any] = {}
+    if isinstance(agent_state.harness, Harness):
+        config["system_prompts"] = dict(agent_state.harness.system_prompts)
+        config["playbook"] = agent_state.harness.playbook.to_dict()
+    config["router"] = agent_state.router.to_dict()
+    return config
+
+
 def learning_loop(
     adapter: AdapterLike,
     agent_state: AgentState,
@@ -145,6 +164,9 @@ def learning_loop(
     intensity: AdaptiveIntensity | None = None,
     output_dir: str | Path | None = None,
     after_iteration: "Callable[[int, AgentState, list[Episode]], None] | None" = None,
+    archive: ArchiveStore | None = None,
+    bench: str = "unknown",
+    domain_tags: list[str] | None = None,
 ) -> tuple[AgentState, StateID]:
     """Run the unified learning loop.
 
@@ -178,6 +200,56 @@ def learning_loop(
     layers = agent_state.get_layers(active_layers)
     exp_log = ExperimentLog(output_dir)
     evo_log = EvolutionLog(output_dir)
+    _archive: ArchiveStore = archive if archive is not None else NullArchiveStore()
+    _run_id = RunRecord.new_id()
+    _initial_config = _build_agent_config(agent_state)
+    _initial_variant_hash = canonical_hash(_initial_config)
+    _now = time.time()
+    try:
+        _archive.log_run_start(
+            RunRecord(
+                run_id=_run_id,
+                bench=bench,
+                domain_tags=list(domain_tags or []),
+                agent_config=_initial_config,
+                config_hash=_initial_variant_hash,
+                n_iterations=n_iterations,
+                best_reward=0.0,
+                improvement_delta=0.0,
+                total_cost_tokens=0,
+                parent_run_id=None,
+                created_at=_now,
+                completed_at=None,
+            )
+        )
+    except Exception:
+        log.warning("Archive: failed to log run start", exc_info=True)
+    try:
+        _archive.log_variant(
+            AgentVariant(
+                variant_hash=_initial_variant_hash,
+                system_prompt=(
+                    next(iter(agent_state.harness.system_prompts.values()), "")
+                    if isinstance(agent_state.harness, Harness)
+                    else ""
+                ),
+                playbook_snapshot=(
+                    agent_state.harness.playbook.to_dict()
+                    if isinstance(agent_state.harness, Harness)
+                    else {}
+                ),
+                model="",
+                tools=[],
+                first_seen_run_id=_run_id,
+                created_at=_now,
+            )
+        )
+    except Exception:
+        log.warning("Archive: failed to log initial variant", exc_info=True)
+    _prev_variant_hash = _initial_variant_hash
+    _best_reward: float | None = None  # None until first iteration — handles negative rewards
+    _initial_reward: float | None = None
+    _total_cost = 0
     prev_avg_reward = 0.0
     log.info("Starting learning loop — initial state: %s", state_id.combined_hash[:12])
 
@@ -209,6 +281,44 @@ def learning_loop(
             else 0.0
         )
         log.info("  Collected %d episodes, avg reward: %.4f", len(episodes), avg_reward)
+
+        if episodes:
+            _ep_records: list[EpisodeRecord] = []
+            for ep in episodes:
+                tool_call_count = sum(len(m.tool_calls or []) for m in ep.messages)
+                _ep_records.append(
+                    EpisodeRecord(
+                        run_id=_run_id,
+                        iteration_num=iteration,
+                        episode_id=ep.id,
+                        task_id=ep.task_id,
+                        bench=ep.bench,
+                        model=ep.model or "",
+                        reward=ep.summary.normalized_reward(),
+                        signals={
+                            k: {"value": s.value, "confidence": s.confidence}
+                            for k, s in ep.summary.signals.items()
+                        } if ep.summary.signals else {},
+                        n_steps=ep.n_steps(),
+                        n_tool_calls=tool_call_count,
+                        token_usage=(
+                            {
+                                "prompt_tokens": ep.summary.token_usage.prompt_tokens,
+                                "completion_tokens": ep.summary.token_usage.completion_tokens,
+                                "total_tokens": ep.summary.token_usage.total_tokens,
+                            }
+                            if ep.summary.token_usage
+                            else {}
+                        ),
+                        latency_ms=int(ep.summary.timing.total_ms if ep.summary.timing else 0),
+                        messages_ref=f"traces/{ep.id}.json",
+                        created_at=ep.created_at if ep.created_at is not None else time.time(),
+                    )
+                )
+            try:
+                _archive.log_episodes(_ep_records)
+            except Exception:
+                log.warning("Archive: failed to log episodes", exc_info=True)
 
         # Record reward for adaptive intensity
         if intensity is not None:
@@ -384,6 +494,63 @@ def learning_loop(
                 ),
             ))
 
+        try:
+            _cur_config = _build_agent_config(agent_state)
+            _cur_variant_hash = canonical_hash(_cur_config)
+            _evolver_action: dict[str, Any] = {}
+            for name, result in fb_results.items():
+                if result.status == "ok":
+                    _evolver_action[name] = result.metrics
+            _iter_cost = sum(
+                r.metrics.get("tokens_used", 0)
+                for r in fb_results.values()
+                if r.status == "ok"
+            )
+            _total_cost += _iter_cost
+            _archive.log_iteration(
+                IterationRecord(
+                    run_id=_run_id,
+                    iteration_num=iteration,
+                    harness_snapshot_hash=state_id.harness_hash,
+                    mean_reward=avg_reward,
+                    reward_trajectory=[ep.summary.normalized_reward() for ep in episodes],
+                    evolver_action=_evolver_action,
+                    cost_tokens=_iter_cost,
+                    parent_variant_hash=_prev_variant_hash,
+                    child_variant_hash=_cur_variant_hash,
+                    reward_delta=avg_reward - prev_avg_reward,
+                    created_at=time.time(),
+                )
+            )
+            if _cur_variant_hash != _prev_variant_hash:
+                _archive.log_variant(
+                    AgentVariant(
+                        variant_hash=_cur_variant_hash,
+                        system_prompt=(
+                            next(iter(agent_state.harness.system_prompts.values()), "")
+                            if isinstance(agent_state.harness, Harness)
+                            else ""
+                        ),
+                        playbook_snapshot=(
+                            agent_state.harness.playbook.to_dict()
+                            if isinstance(agent_state.harness, Harness)
+                            else {}
+                        ),
+                        model="",
+                        tools=[],
+                        first_seen_run_id=_run_id,
+                        created_at=time.time(),
+                    )
+                )
+                _prev_variant_hash = _cur_variant_hash
+        except Exception:
+            log.warning("Archive: failed to log iteration %d", iteration, exc_info=True)
+
+        if _best_reward is None or avg_reward > _best_reward:
+            _best_reward = avg_reward
+        if _initial_reward is None:
+            _initial_reward = avg_reward
+
         prev_avg_reward = avg_reward
 
         # 7. Optional after-iteration callback (e.g. eval scoring)
@@ -392,6 +559,18 @@ def learning_loop(
                 after_iteration(iteration, agent_state, episodes)
             except Exception:
                 log.exception("after_iteration callback failed")
+
+    try:
+        final_best = _best_reward if _best_reward is not None else 0.0
+        final_initial = _initial_reward if _initial_reward is not None else 0.0
+        _archive.log_run_complete(
+            _run_id,
+            final_best,
+            final_best - final_initial,
+            total_cost_tokens=_total_cost,
+        )
+    except Exception:
+        log.warning("Archive: failed to log run complete", exc_info=True)
 
     log.info("Loop complete — final state: %s", state_id.combined_hash[:12])
     return agent_state, state_id

--- a/clawloop/utils/content_hash.py
+++ b/clawloop/utils/content_hash.py
@@ -1,0 +1,32 @@
+"""Deterministic content hashing for reproducible identity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def _safe_default(obj: Any) -> str:
+    log.warning(
+        "Non-serializable object in canonical_json: %s (%s)",
+        type(obj).__name__,
+        obj,
+    )
+    return str(obj)
+
+
+def canonical_json(obj: Any) -> str:
+    """Deterministic JSON serialization (sorted keys, compact separators)."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=_safe_default)
+
+
+def sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+def canonical_hash(obj: dict[str, Any]) -> str:
+    return sha256_hex(canonical_json(obj))

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -1,0 +1,91 @@
+"""Integration tests — learning_loop with a JsonlArchiveStore captures data."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+from pathlib import Path
+
+from clawloop.archive.jsonl_store import JsonlArchiveStore
+from clawloop.core.episode import Episode, EpisodeSummary, Message, StepMeta
+from clawloop.core.loop import AgentState, learning_loop
+from clawloop.learning_layers.harness import Harness
+from clawloop.learning_layers.router import Router
+from clawloop.learning_layers.weights import Weights
+
+
+class FakeAdapter:
+    def run_episode(self, task, agent_state):  # type: ignore[no-untyped-def]
+        return Episode(
+            id=Episode.new_id(),
+            state_id="test-state",
+            task_id=str(task),
+            bench="test",
+            messages=[Message(role="user", content="hello")],
+            step_boundaries=[0],
+            steps=[StepMeta(t=0, reward=0.8, done=True, timing_ms=100.0)],
+            summary=EpisodeSummary(total_reward=0.8),
+            model="gpt-4",
+            created_at=time.time(),
+        )
+
+
+class TestLearningLoopArchive:
+    def test_archive_captures_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_dir = Path(tmpdir) / "arch"
+            archive = JsonlArchiveStore(archive_dir=archive_dir)
+            agent_state = AgentState(
+                harness=Harness(system_prompts={"test": "You are helpful."}),
+                router=Router(),
+                weights=Weights(),
+            )
+            adapter = FakeAdapter()
+
+            learning_loop(
+                adapter,
+                agent_state,
+                ["task-1", "task-2"],
+                n_episodes=2,
+                n_iterations=2,
+                output_dir=tmpdir,
+                archive=archive,
+            )
+
+            runs_file = archive_dir / "runs.jsonl"
+            assert runs_file.exists()
+            run_lines = [json.loads(ln) for ln in runs_file.read_text().splitlines() if ln.strip()]
+            starts = [r for r in run_lines if r["record_type"] == "run_start"]
+            completes = [r for r in run_lines if r["record_type"] == "run_complete"]
+            assert len(starts) == 1
+            assert len(completes) == 1
+
+            iterations_file = archive_dir / "iterations.jsonl"
+            iter_lines = [json.loads(ln) for ln in iterations_file.read_text().splitlines() if ln.strip()]
+            assert len(iter_lines) == 2
+            assert {r["iteration_num"] for r in iter_lines} == {0, 1}
+
+            run_id = starts[0]["run_id"]
+            episodes_file = archive_dir / run_id / "episodes.jsonl"
+            ep_lines = [json.loads(ln) for ln in episodes_file.read_text().splitlines() if ln.strip()]
+            assert len(ep_lines) == 4  # 2 iterations * 2 episodes
+
+            got = archive.get_run(run_id)
+            assert got is not None
+            assert got.completed_at is not None
+
+    def test_archive_none_is_safe(self) -> None:
+        agent_state = AgentState(
+            harness=Harness(system_prompts={"test": "You are helpful."}),
+            router=Router(),
+            weights=Weights(),
+        )
+        learning_loop(
+            FakeAdapter(),
+            agent_state,
+            ["task-1"],
+            n_episodes=1,
+            n_iterations=1,
+            archive=None,
+        )

--- a/tests/test_archive_jsonl_store.py
+++ b/tests/test_archive_jsonl_store.py
@@ -1,0 +1,280 @@
+"""Tests for JsonlArchiveStore — public append-only JSONL archive."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from clawloop.archive.jsonl_store import JsonlArchiveStore
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+
+
+def _make_run(run_id: str = "r1", **overrides) -> RunRecord:
+    kwargs = dict(
+        run_id=run_id,
+        bench="test-bench",
+        domain_tags=["math", "arithmetic"],
+        agent_config={"prompt": "hello"},
+        config_hash="cfg-hash-1",
+        n_iterations=3,
+        best_reward=0.0,
+        improvement_delta=0.0,
+        total_cost_tokens=0,
+        parent_run_id=None,
+        created_at=time.time(),
+        completed_at=None,
+    )
+    kwargs.update(overrides)
+    return RunRecord(**kwargs)
+
+
+def _make_iter(run_id: str = "r1", n: int = 0) -> IterationRecord:
+    return IterationRecord(
+        run_id=run_id,
+        iteration_num=n,
+        harness_snapshot_hash="snap",
+        mean_reward=0.5,
+        reward_trajectory=[0.4, 0.5, 0.6],
+        evolver_action={"harness": {"insights_generated": 2}},
+        cost_tokens=100,
+        parent_variant_hash="p",
+        child_variant_hash="c",
+        reward_delta=0.1,
+        created_at=time.time(),
+    )
+
+
+def _make_episode(run_id: str = "r1", ep_id: str = "e1") -> EpisodeRecord:
+    return EpisodeRecord(
+        run_id=run_id,
+        iteration_num=0,
+        episode_id=ep_id,
+        task_id="t1",
+        bench="test-bench",
+        model="gpt-4o",
+        reward=0.7,
+        signals={},
+        n_steps=3,
+        n_tool_calls=1,
+        token_usage={"total_tokens": 200},
+        latency_ms=1200,
+        messages_ref="traces/e1.json",
+        created_at=time.time(),
+    )
+
+
+def _make_variant(vhash: str = "v1") -> AgentVariant:
+    return AgentVariant(
+        variant_hash=vhash,
+        system_prompt="hi",
+        playbook_snapshot={},
+        model="gpt-4o",
+        tools=[],
+        first_seen_run_id="r1",
+        created_at=time.time(),
+    )
+
+
+def test_log_and_read_run(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    run = _make_run()
+    store.log_run_start(run)
+
+    got = store.get_run(run.run_id)
+    assert got is not None
+    assert got.run_id == run.run_id
+    assert got.config_hash == run.config_hash
+    assert got.completed_at is None
+
+
+def test_run_complete_updates_totals(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_run_start(_make_run())
+    store.log_run_complete("r1", best_reward=0.9, improvement_delta=0.3, total_cost_tokens=500)
+
+    got = store.get_run("r1")
+    assert got is not None
+    assert got.best_reward == 0.9
+    assert got.improvement_delta == 0.3
+    assert got.total_cost_tokens == 500
+    assert got.completed_at is not None
+
+
+def test_get_run_missing_returns_none(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    assert store.get_run("missing") is None
+
+
+def test_log_iteration_appends_line(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_iteration(_make_iter())
+    store.log_iteration(_make_iter(n=1))
+
+    lines = (tmp_path / "iterations.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 2
+    rec = json.loads(lines[0])
+    assert rec["record_type"] == "iteration"
+    assert rec["iteration_num"] == 0
+
+
+def test_log_episodes_writes_under_run_dir(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_episodes([_make_episode(ep_id="e1"), _make_episode(ep_id="e2")])
+
+    ep_file = tmp_path / "r1" / "episodes.jsonl"
+    assert ep_file.exists()
+    lines = ep_file.read_text().strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["episode_id"] == "e1"
+    assert json.loads(lines[1])["episode_id"] == "e2"
+
+
+def test_log_episodes_empty_is_noop(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_episodes([])  # no exception, no file created
+    assert not (tmp_path / "r1").exists()
+
+
+def test_log_variant_appends(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_variant(_make_variant("v1"))
+    store.log_variant(_make_variant("v2"))
+
+    lines = (tmp_path / "variants.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 2
+
+
+def test_get_similar_runs_by_config_hash(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_run_start(_make_run(run_id="a", config_hash="H"))
+    store.log_run_start(_make_run(run_id="b", config_hash="H", domain_tags=["nlp"]))
+    store.log_run_start(_make_run(run_id="c", config_hash="OTHER", domain_tags=["other"]))
+    store.log_run_complete("a", 0.8, 0.1, 0)
+    store.log_run_complete("b", 0.9, 0.2, 0)
+    store.log_run_complete("c", 0.95, 0.3, 0)
+
+    hits = store.get_similar_runs(config_hash="H", domain_tags=[])
+    hit_ids = {r.run_id for r in hits}
+    assert hit_ids == {"a", "b"}
+    # Ordered by best_reward desc
+    assert hits[0].run_id == "b"
+
+
+def test_get_similar_runs_by_tag(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_run_start(_make_run(run_id="a", config_hash="X", domain_tags=["math"]))
+    store.log_run_start(_make_run(run_id="b", config_hash="Y", domain_tags=["nlp"]))
+    store.log_run_start(_make_run(run_id="c", config_hash="Z", domain_tags=["vision"]))
+
+    hits = store.get_similar_runs(config_hash="NO_MATCH", domain_tags=["math", "nlp"])
+    assert {r.run_id for r in hits} == {"a", "b"}
+
+
+def test_get_similar_runs_limit(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    for i in range(5):
+        store.log_run_start(_make_run(run_id=f"r{i}", config_hash="H"))
+        store.log_run_complete(f"r{i}", best_reward=0.1 * i, improvement_delta=0.0, total_cost_tokens=0)
+
+    hits = store.get_similar_runs(config_hash="H", domain_tags=[], limit=3)
+    assert len(hits) == 3
+    assert hits[0].run_id == "r4"  # highest reward
+
+
+def test_thread_safe_concurrent_writes(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+
+    def writer(tid: int) -> None:
+        for i in range(20):
+            store.log_iteration(_make_iter(run_id=f"run-{tid}", n=i))
+
+    threads = [threading.Thread(target=writer, args=(t,)) for t in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = (tmp_path / "iterations.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 4 * 20
+    for line in lines:
+        # Every line must be complete valid JSON (no interleaving)
+        json.loads(line)
+
+
+def test_context_manager(tmp_path: Path) -> None:
+    with JsonlArchiveStore(tmp_path) as store:
+        store.log_run_start(_make_run())
+    # no exception == pass
+    assert (tmp_path / "runs.jsonl").exists()
+
+
+def test_ignores_malformed_lines(tmp_path: Path) -> None:
+    """Readers must tolerate a partial tail line from a crash."""
+    store = JsonlArchiveStore(tmp_path)
+    store.log_run_start(_make_run())
+    # Simulate a crash mid-write by appending a partial line
+    with open(tmp_path / "runs.jsonl", "a", encoding="utf-8") as f:
+        f.write('{"record_type": "run_start", "run_id": "par')
+
+    got = store.get_run("r1")
+    assert got is not None
+    assert got.run_id == "r1"
+
+
+def test_schema_version_tag(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    store.log_run_start(_make_run())
+    rec = json.loads((tmp_path / "runs.jsonl").read_text().strip().splitlines()[0])
+    assert rec.get("_schema") == 1
+
+
+def _make_episode_custom(run_id: str) -> EpisodeRecord:
+    ep = _make_episode()
+    return EpisodeRecord(
+        run_id=run_id,
+        iteration_num=ep.iteration_num,
+        episode_id=ep.episode_id,
+        task_id=ep.task_id,
+        bench=ep.bench,
+        model=ep.model,
+        reward=ep.reward,
+        signals=ep.signals,
+        n_steps=ep.n_steps,
+        n_tool_calls=ep.n_tool_calls,
+        token_usage=ep.token_usage,
+        latency_ms=ep.latency_ms,
+        messages_ref=ep.messages_ref,
+        created_at=ep.created_at,
+    )
+
+
+def test_log_episodes_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    with pytest.raises(ValueError):
+        store.log_episodes([_make_episode_custom("../escape")])
+    with pytest.raises(ValueError):
+        store.log_episodes([_make_episode_custom("sub/dir")])
+
+
+def test_get_run_handles_orphan_complete(tmp_path: Path) -> None:
+    """run_complete without a prior run_start should not crash get_run."""
+    store = JsonlArchiveStore(tmp_path)
+    store.log_run_complete("ghost", 0.5, 0.1, 0)
+    assert store.get_run("ghost") is None
+
+
+def test_log_episodes_rejects_mixed_run_batch(tmp_path: Path) -> None:
+    store = JsonlArchiveStore(tmp_path)
+    ep_a = _make_episode(ep_id="ea")
+    ep_b = _make_episode_custom("other-run")
+    with pytest.raises(ValueError, match="share a run_id"):
+        store.log_episodes([ep_a, ep_b])

--- a/tests/test_archive_schema.py
+++ b/tests/test_archive_schema.py
@@ -1,0 +1,162 @@
+"""Tests for content hashing utils and archive schema types."""
+
+import time
+
+from clawloop.archive.schema import (
+    AgentVariant,
+    EpisodeRecord,
+    IterationRecord,
+    RunRecord,
+)
+from clawloop.utils.content_hash import canonical_hash, canonical_json, sha256_hex
+
+
+class TestCanonicalJson:
+    def test_sorted_keys(self) -> None:
+        assert canonical_json({"b": 1, "a": 2}) == '{"a":2,"b":1}'
+
+    def test_no_whitespace(self) -> None:
+        result = canonical_json({"key": "value"})
+        assert " " not in result
+
+    def test_deterministic(self) -> None:
+        obj = {"z": [3, 2, 1], "a": {"nested": True}}
+        assert canonical_json(obj) == canonical_json(obj)
+
+    def test_nested_sort(self) -> None:
+        obj = {"b": {"d": 1, "c": 2}, "a": 0}
+        result = canonical_json(obj)
+        assert result == '{"a":0,"b":{"c":2,"d":1}}'
+
+
+class TestCanonicalHash:
+    def test_returns_64_char_hex(self) -> None:
+        h = canonical_hash({"x": 1})
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_deterministic(self) -> None:
+        obj = {"key": "value", "n": 42}
+        assert canonical_hash(obj) == canonical_hash(obj)
+
+    def test_key_order_irrelevant(self) -> None:
+        assert canonical_hash({"a": 1, "b": 2}) == canonical_hash({"b": 2, "a": 1})
+
+    def test_different_input_different_hash(self) -> None:
+        assert canonical_hash({"a": 1}) != canonical_hash({"a": 2})
+
+    def test_sha256_hex_matches(self) -> None:
+        obj = {"hello": "world"}
+        expected = sha256_hex(canonical_json(obj))
+        assert canonical_hash(obj) == expected
+
+
+# --- Schema roundtrip tests ---
+
+_NOW = time.time()
+
+
+def _sample_run() -> RunRecord:
+    return RunRecord(
+        run_id=RunRecord.new_id(),
+        bench="swe-bench-lite",
+        domain_tags=["coding", "python"],
+        agent_config={"model": "gpt-4", "temperature": 0.7},
+        config_hash="a" * 64,
+        n_iterations=10,
+        best_reward=0.85,
+        improvement_delta=0.15,
+        total_cost_tokens=50000,
+        parent_run_id=None,
+        created_at=_NOW,
+        completed_at=_NOW + 3600,
+    )
+
+
+def _sample_iteration() -> IterationRecord:
+    return IterationRecord(
+        run_id="abc123",
+        iteration_num=3,
+        harness_snapshot_hash="b" * 64,
+        mean_reward=0.72,
+        reward_trajectory=[0.5, 0.6, 0.72],
+        evolver_action={"type": "mutate", "target": "system_prompt"},
+        cost_tokens=5000,
+        parent_variant_hash="c" * 64,
+        child_variant_hash="d" * 64,
+        reward_delta=0.12,
+        created_at=_NOW,
+    )
+
+
+def _sample_episode() -> EpisodeRecord:
+    return EpisodeRecord(
+        run_id="abc123",
+        iteration_num=3,
+        episode_id="ep-001",
+        task_id="task-42",
+        bench="swe-bench-lite",
+        model="gpt-4",
+        reward=0.9,
+        signals={"outcome": 0.9, "execution": 0.8},
+        n_steps=5,
+        n_tool_calls=3,
+        token_usage={"prompt": 1000, "completion": 500},
+        latency_ms=2500,
+        messages_ref="s3://bucket/ep-001.jsonl",
+        created_at=_NOW,
+    )
+
+
+def _sample_variant() -> AgentVariant:
+    return AgentVariant(
+        variant_hash="e" * 64,
+        system_prompt="You are a helpful coding assistant.",
+        playbook_snapshot={"rules": ["be concise"]},
+        model="gpt-4",
+        tools=["search", "bash", "edit"],
+        first_seen_run_id="abc123",
+        created_at=_NOW,
+    )
+
+
+class TestRunRecord:
+    def test_to_dict_roundtrip(self) -> None:
+        rec = _sample_run()
+        d = rec.to_dict()
+        restored = RunRecord.from_dict(d)
+        assert restored == rec
+
+    def test_to_dict_keys(self) -> None:
+        rec = _sample_run()
+        d = rec.to_dict()
+        expected_keys = {
+            "run_id", "bench", "domain_tags", "agent_config", "config_hash",
+            "n_iterations", "best_reward", "improvement_delta",
+            "total_cost_tokens", "parent_run_id", "created_at", "completed_at",
+        }
+        assert set(d.keys()) == expected_keys
+
+
+class TestIterationRecord:
+    def test_to_dict_roundtrip(self) -> None:
+        rec = _sample_iteration()
+        d = rec.to_dict()
+        restored = IterationRecord.from_dict(d)
+        assert restored == rec
+
+
+class TestEpisodeRecord:
+    def test_to_dict_roundtrip(self) -> None:
+        rec = _sample_episode()
+        d = rec.to_dict()
+        restored = EpisodeRecord.from_dict(d)
+        assert restored == rec
+
+
+class TestAgentVariant:
+    def test_to_dict_roundtrip(self) -> None:
+        rec = _sample_variant()
+        d = rec.to_dict()
+        restored = AgentVariant.from_dict(d)
+        assert restored == rec


### PR DESCRIPTION
## Summary

Public evolution archive: structured data capture for learning runs.

- `ArchiveStore` protocol, `NullArchiveStore`, `JsonlArchiveStore` (append-only JSONL, zero-dep, thread-safe, crash-tolerant)
- Schema dataclasses: `RunRecord`, `IterationRecord`, `EpisodeRecord`, `AgentVariant`
- `content_hash` utility (canonical JSON + SHA-256)
- `learning_loop()` wiring: `archive=`, `bench=`, `domain_tags=` kwargs
- 3 test files (35 tests total)

## Test plan

- [x] 993 passed / 38 skipped
- [x] No enterprise leaks
- [x] 2x code-review SHIP IT + 2x Codex SHIP IT
- [ ] CI on this repo