### PR TITLE
feat: Tinker weight-tuning example + OpenSpiel RL env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# ClawLoop — environment configuration
+# Copy to clawloop/.env and fill in your values. clawloop/.env is gitignored.
+# clawloop.config.load_env() discovers this file automatically at runtime.
+
+# Tinker (managed LoRA training) — required for weight_backend=tinker.
+# Obtain via Thinking Machines Lab (https://thinkingmachines.ai).
+# TINKER_API_KEY=
+
+# Optional: weights & biases (cross-run dashboards). Pass --wandb-project NAME
+# on run_pilot.py to enable. If unset, pretty-console + jsonl still work.
+# WANDB_API_KEY=
+# Optional: Neptune (auto-enabled alongside wandb when both are set).
+# NEPTUNE_API_TOKEN=
+
+# Sampling / LLM client (used by harness & reflector, OpenAI-compatible).
+# CLAWLOOP_API_BASE=https://api.openai.com/v1
+# CLAWLOOP_API_KEY=
+# CLAWLOOP_MODEL=gpt-4o-mini

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ examples/openclaw_runner/package-lock.json
 # Runtime artifacts
 playbook.json
 runs/
+pilot_runs/

--- a/clawloop/config.py
+++ b/clawloop/config.py
@@ -1,0 +1,59 @@
+"""Environment config loading for ClawLoop.
+
+Loads `.env` so users don't have to source/export by hand. Idempotent; safe
+to call multiple times. Lookup order (first hit wins, later files do not
+override earlier ones):
+
+1. ``$CLAWLOOP_ENV_FILE`` — explicit path override.
+2. ``clawloop/.env`` — package-scoped, colocated with code.
+3. Nearest ``.env`` walking up from the current working directory.
+
+Missing files are skipped silently. Existing environment variables are never
+overridden (so CI/CD injected secrets always win over local ``.env``).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_loaded: bool = False
+
+
+def load_env(*, force: bool = False) -> list[Path]:
+    """Load .env files. Returns the list of paths actually loaded.
+
+    Args:
+        force: If True, reloads even if load_env has already been called in
+               this process. Default False for cheap idempotency.
+    """
+    global _loaded
+    if _loaded and not force:
+        return []
+
+    try:
+        from dotenv import find_dotenv, load_dotenv
+    except ImportError:
+        _loaded = True
+        return []
+
+    loaded: list[Path] = []
+
+    override = os.environ.get("CLAWLOOP_ENV_FILE")
+    if override:
+        p = Path(override)
+        if p.is_file():
+            load_dotenv(p, override=False)
+            loaded.append(p)
+
+    pkg_env = Path(__file__).resolve().parent.parent / ".env"
+    if pkg_env.is_file():
+        load_dotenv(pkg_env, override=False)
+        loaded.append(pkg_env)
+
+    nearest = find_dotenv(usecwd=True)
+    if nearest and Path(nearest).resolve() not in {p.resolve() for p in loaded}:
+        load_dotenv(nearest, override=False)
+        loaded.append(Path(nearest))
+
+    _loaded = True
+    return loaded

--- a/clawloop/core/loop.py
+++ b/clawloop/core/loop.py
@@ -50,11 +50,36 @@ class ExperimentLog:
     (flush after each write).
     """
 
-    def __init__(self, output_dir: str | Path | None = None):
+    def __init__(
+        self,
+        output_dir: str | Path | None = None,
+        *,
+        wandb_project: str | None = None,
+        wandb_name: str | None = None,
+    ):
         self._path: Path | None = None
         if output_dir:
             self._path = Path(output_dir) / "experiment.jsonl"
             self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Optional cookbook logger: always emits a Rich console table; opt-in
+        # for wandb / neptune via setup_logging args + env vars. We keep our
+        # own experiment.jsonl as the canonical disk-of-record; the cookbook
+        # logger ALSO writes its own metrics.jsonl alongside.
+        self._ml_logger: Any | None = None
+        if output_dir:
+            try:
+                from tinker_cookbook.utils import ml_log
+                self._ml_logger = ml_log.setup_logging(
+                    log_dir=str(Path(output_dir).expanduser()),
+                    wandb_project=wandb_project,
+                    wandb_name=wandb_name,
+                    config=None,
+                )
+            except Exception as e:
+                # Best-effort — never abort training because Rich/wandb failed.
+                log.warning("ml_log.setup_logging failed: %s; falling back to JSONL only", e)
+                self._ml_logger = None
 
     def log_iteration(
         self,
@@ -62,21 +87,61 @@ class ExperimentLog:
         episodes: list[Episode],
         fb_results: dict[str, FBResult],
         harness: Harness | None = None,
+        backend: Any | None = None,
     ) -> None:
         if self._path is None:
             return
         rewards = [ep.summary.total_reward for ep in episodes]
-        per_task = {
-            ep.task_id: {
-                "reward": ep.summary.total_reward,
-                "signals": {
-                    k: {"value": s.value, "confidence": s.confidence}
-                    for k, s in ep.summary.signals.items()
-                } if ep.summary.signals else {},
-                "error": ep.metadata.get("error") if ep.metadata else None,
+        # Aggregate across GRPO duplicates (the same task_id can appear K times
+        # in one iter — we don't want the dict-comprehension last-wins
+        # behaviour to drop K-1 rollouts). Emit summary stats per task_id +
+        # the list of rewards so downstream viz can plot per-rollout if it
+        # wants.
+        by_task: dict[str, list] = {}
+        for ep in episodes:
+            by_task.setdefault(ep.task_id, []).append(ep)
+        per_task: dict[str, dict] = {}
+        for tid, eps in by_task.items():
+            task_rewards = [e.summary.total_reward for e in eps]
+            errors = [e.metadata.get("error") for e in eps if e.metadata and e.metadata.get("error")]
+            # Latest episode's signals in the original {value, confidence} shape —
+            # keeps the existing viewer (`learning_viewer.html` reads
+            # `info.signals.<name>.value`) working without a simultaneous viewer
+            # rewrite. All K rollouts' signals are preserved in `rollouts[]`
+            # for the eventual viewer revamp.
+            latest = eps[-1]
+            latest_signals: dict[str, dict[str, Any]] = {}
+            if latest.summary.signals:
+                for k, s in latest.summary.signals.items():
+                    latest_signals[k] = {
+                        "value": s.value, "confidence": s.confidence,
+                    }
+            rollouts = [
+                {
+                    "reward": e.summary.total_reward,
+                    "error": (e.metadata.get("error") if e.metadata else None),
+                    "signals": {
+                        k: {"value": s.value, "confidence": s.confidence}
+                        for k, s in (e.summary.signals or {}).items()
+                    },
+                }
+                for e in eps
+            ]
+            mean_reward = sum(task_rewards) / len(task_rewards)
+            per_task[tid] = {
+                # Backward-compatible keys (viewer + existing consumers):
+                "reward": mean_reward,
+                "signals": latest_signals,
+                "error": errors[0] if errors else None,
+                # New per-rollout detail (issue #66 viewer work will use these):
+                "n_rollouts": len(eps),
+                "reward_mean": mean_reward,
+                "reward_min": min(task_rewards),
+                "reward_max": max(task_rewards),
+                "rewards": task_rewards,
+                "errors": errors,
+                "rollouts": rollouts,
             }
-            for ep in episodes
-        }
         entry: dict[str, Any] = {
             "iteration": iteration,
             "timestamp": time.time(),
@@ -90,6 +155,17 @@ class ExperimentLog:
                 for name, r in fb_results.items()
             },
         }
+        if backend is not None and hasattr(backend, "list_tinker_checkpoints"):
+            try:
+                entry["tinker_checkpoints"] = backend.list_tinker_checkpoints()
+            except Exception as e:  # best-effort — never abort the run
+                entry["tinker_checkpoints"] = [
+                    {"error": type(e).__name__, "message": str(e)}
+                ]
+            entry["tinker_model_id"] = getattr(backend, "model_id", None)
+            entry["tinker_durable_paths"] = list(
+                getattr(backend, "_durable_paths", [])
+            )
         if harness is not None:
             entry["playbook_size"] = len(harness.playbook.entries)
             entry["playbook_entries"] = [
@@ -113,6 +189,25 @@ class ExperimentLog:
             entry["max_reward"],
             entry.get("playbook_size", 0),
         )
+        # Mirror to cookbook ml_log (Rich console + opt-in wandb / neptune).
+        if self._ml_logger is not None:
+            try:
+                # Flatten to scalar metrics — wandb/Rich expect numbers, not nested dicts.
+                scalar_metrics: dict[str, Any] = {
+                    "n_episodes":     entry["n_episodes"],
+                    "avg_reward":     entry["avg_reward"],
+                    "min_reward":     entry["min_reward"],
+                    "max_reward":     entry["max_reward"],
+                }
+                for name, r in fb_results.items():
+                    for mk, mv in (r.metrics or {}).items():
+                        if isinstance(mv, (int, float, bool)):
+                            scalar_metrics[f"{name}/{mk}"] = mv
+                if "playbook_size" in entry:
+                    scalar_metrics["playbook/size"] = entry["playbook_size"]
+                self._ml_logger.log_metrics(scalar_metrics, step=iteration)
+            except Exception as e:
+                log.warning("ml_logger.log_metrics failed: %s", e)
 
 
 @dataclass
@@ -123,6 +218,9 @@ class AgentState:
     router: Router = field(default_factory=Router)
     weights: Weights = field(default_factory=Weights)
     inference_url: str | None = None  # vLLM endpoint for Harbor agents
+    sampling_client: Any = None   # Tinker SamplingClient, set per iter by TinkerWeightsBackend; kept Any to avoid tinker import.
+    renderer: Any = None          # tinker_cookbook renderer; set per iter by TinkerWeightsBackend.
+    tokenizer: Any = None         # Tinker training-client tokenizer; set per iter by TinkerWeightsBackend.
     tried_paradigms: list[str] = field(default_factory=list)  # paradigm contents tried
     _prev_playbook_generation: int = 0  # tracks generation for flush logic
 
@@ -163,6 +261,8 @@ def learning_loop(
     active_layers: list[str] | None = None,
     intensity: AdaptiveIntensity | None = None,
     output_dir: str | Path | None = None,
+    wandb_project: str | None = None,
+    wandb_name: str | None = None,
     after_iteration: "Callable[[int, AgentState, list[Episode]], None] | None" = None,
     archive: ArchiveStore | None = None,
     bench: str = "unknown",
@@ -198,7 +298,9 @@ def learning_loop(
     """
     state_id = agent_state.state_id()
     layers = agent_state.get_layers(active_layers)
-    exp_log = ExperimentLog(output_dir)
+    exp_log = ExperimentLog(
+        output_dir, wandb_project=wandb_project, wandb_name=wandb_name,
+    )
     evo_log = EvolutionLog(output_dir)
     _archive: ArchiveStore = archive if archive is not None else NullArchiveStore()
     _run_id = RunRecord.new_id()
@@ -256,6 +358,21 @@ def learning_loop(
     for iteration in range(n_iterations):
         log.info("Iteration %d/%d", iteration + 1, n_iterations)
 
+        # 0. Refresh Tinker-driven fields on AgentState from current backend.
+        # Gated on hasattr so non-Tinker backends (e.g. SkyRL) are untouched.
+        backend = getattr(agent_state.weights, "_backend", None)
+        if backend is not None and hasattr(backend, "current_sampling_client"):
+            from dataclasses import replace as _replace
+
+            agent_state = _replace(
+                agent_state,
+                sampling_client=backend.current_sampling_client(),
+                renderer=getattr(backend, "renderer", None),
+                tokenizer=getattr(backend, "tokenizer", None),
+            )
+            # Refresh the layers view against the (possibly) new agent_state.
+            layers = agent_state.get_layers(active_layers)
+
         # 1. Collect episodes
         if not tasks or n_episodes <= 0:
             episodes: list[Episode] = []
@@ -269,6 +386,13 @@ def learning_loop(
                 getattr(adapter, "run_batch", None)
             ):
                 episodes = adapter.run_batch(agent_state, selected_tasks)
+            elif hasattr(adapter, "run_episodes_batch") and callable(
+                getattr(adapter, "run_episodes_batch", None)
+            ):
+                # Concurrent rollout path (OpenSpielGameAdapter): all
+                # episodes for this iter fan out under one event loop,
+                # Tinker queues them as parallel ConcurrentFutures.
+                episodes = adapter.run_episodes_batch(selected_tasks, agent_state)
             else:
                 episodes = []
                 for task in selected_tasks:
@@ -447,6 +571,37 @@ def learning_loop(
                     except Exception:
                         log.exception("  rollback failed for %s", name)
 
+        # 4b. Tinker save_state hook — persist intermediate weights and swap
+        # the backend's internal SamplingClient so the next iter picks up the
+        # freshly-trained adapter on its top-of-iter refresh.  Gated on
+        # hasattr so SkyRL-style backends are unaffected.
+        #
+        # Skip the save entirely when the weights step produced zero datums
+        # (GRPO filtered every group for zero variance) — checkpointing an
+        # unchanged adapter wastes Tinker quota and pollutes the durable-path
+        # timeline.
+        weights_fb = fb_results.get("weights")
+        n_datums = (
+            weights_fb.metrics.get("n_datums", 0)
+            if weights_fb is not None and weights_fb.metrics
+            else 0
+        )
+        if (
+            backend is not None
+            and hasattr(backend, "save_state")
+            and n_datums > 0
+        ):
+            try:
+                backend.save_state(f"iter_{iteration}").result()
+            except Exception:
+                log.exception("backend.save_state failed for iter_%d", iteration)
+        elif backend is not None and hasattr(backend, "save_state"):
+            log.info(
+                "  [save_state] skipped iter_%d — no datums produced "
+                "(GRPO filtered all groups)",
+                iteration,
+            )
+
         # Generation flush: when playbook_generation advances, clear stale
         # episodes from weights buffer to prevent RL learning pre-adaptation behavior
         if isinstance(agent_state.harness, Harness) and not optim_failed:
@@ -463,7 +618,7 @@ def learning_loop(
 
         # 5. Log iteration results
         harness_ref = agent_state.harness if isinstance(agent_state.harness, Harness) else None
-        exp_log.log_iteration(iteration, episodes, fb_results, harness_ref)
+        exp_log.log_iteration(iteration, episodes, fb_results, harness_ref, backend=backend)
 
         # 6. Recompute state identity and log evolution entry
         prev_hash = state_id.combined_hash

--- a/clawloop/environments/openspiel.py
+++ b/clawloop/environments/openspiel.py
@@ -1,0 +1,722 @@
+"""OpenSpiel environment adapter for ClawLoop.
+
+Wraps OpenSpiel games + game_arena prompt/parse primitives. Each
+`OpenSpielTaskEnvironment` is one (game, seed) pair; running it produces
+a ClawLoop `Episode`. The adapter dispatches by task_id.
+
+Design invariants for ``run_episode``:
+
+- CHANCE nodes are advanced by sampling from ``state.chance_outcomes()`` with
+  a seeded ``numpy.random.default_rng``. No LLM call, no message appended,
+  no StepMeta recorded.
+- LLM turns persist exact tokens: ``prompt_tokens`` go on the ``StepMeta.info``
+  bag and ``sampled_tokens`` + ``sampling_logprobs`` pair up in
+  ``Message.logprobs``. The downstream exporter never re-tokenizes.
+- The terminal reward lives on ``summary.signals["outcome"]`` (name-keyed)
+  so :meth:`EpisodeSummary.effective_reward` returns the canonical [-1, 1]
+  value for the LLM player.
+"""
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, replace as dc_replace
+from typing import Any, Literal, Protocol
+
+
+# The LLM always plays as seat 0 across every game in this env. Opponents
+# (including self-play in a future release) cover seats 1..N-1.
+LLM_PID: int = 0
+
+
+class OpponentPolicy(Protocol):
+    """Scripted policy for non-LLM players (2P+ games only)."""
+    def act(self, state: Any) -> int: ...
+
+
+class RandomPolicy:
+    """Uniformly sample a legal action for the current player.
+
+    Works for every OpenSpiel turn-based game. For simultaneous-move games the
+    driver loop queries ``act(state, player_id)`` via the compatible
+    :meth:`act_for_player` shim — the Protocol stays minimal.
+    """
+
+    def __init__(self, seed: int | None = None) -> None:
+        import numpy as _np
+        self._rng = _np.random.default_rng(seed)
+
+    def act(self, state: Any) -> int:
+        legal = state.legal_actions()
+        return int(self._rng.choice(legal))
+
+    def act_for_player(self, state: Any, player: int) -> int:
+        legal = state.legal_actions(player)
+        return int(self._rng.choice(legal))
+
+
+def _resolve_opponent(spec: Any) -> OpponentPolicy | None:
+    """Translate a YAML ``opponent`` spec into an :class:`OpponentPolicy`.
+
+    Accepted forms:
+        None / missing            -> no opponent (1P / chance-only game)
+        "random"                  -> :class:`RandomPolicy`
+        {"type": "random", "seed": 7}
+        an already-instantiated OpponentPolicy               -> passed through
+    """
+    if spec is None:
+        return None
+    if isinstance(spec, str):
+        if spec == "random":
+            return RandomPolicy()
+        raise ValueError(f"unknown opponent spec: {spec!r}")
+    if isinstance(spec, dict):
+        kind = spec.get("type")
+        if kind == "random":
+            return RandomPolicy(seed=spec.get("seed"))
+        raise ValueError(f"unknown opponent spec: {spec!r}")
+    # Assume caller gave us an OpponentPolicy-like object.
+    return spec
+
+
+@dataclass
+class OpenSpielTaskConfig:
+    game_name: str                                   # e.g. "blackjack"
+    seeds: list[int]                                 # scenario pool
+    prompt_style: Literal["canonical", "ascii"] = "canonical"
+    rethink_k: int = 3
+    max_turns: int = 50
+    opponent: OpponentPolicy | None = None           # None for 1P games
+    temperature: float = 1.0
+    top_p: float = 0.95
+    max_tokens: int = 128
+
+
+def _build_generation_prompt_tokens(
+    renderer: Any, tokenizer: Any, messages: list,
+) -> list[int]:
+    """Render messages into prompt tokens the SamplingClient will consume.
+
+    Preferred: ``renderer.build_generation_prompt(messages) -> list[int]``.
+    Fallback: serialize to OpenAI-style dicts and use
+    ``tokenizer.apply_chat_template(..., tokenize=True, add_generation_prompt=True)``.
+    The fallback lets us support renderer API drift across tinker_cookbook
+    versions without breaking the env.
+    """
+    # tinker_cookbook renderers expect dicts with ["role"]/["content"] keys,
+    # not ClawLoop Message dataclasses. Serialize first.
+    openai_msgs = [m.to_openai_dict() for m in messages]
+    if hasattr(renderer, "build_generation_prompt"):
+        out = renderer.build_generation_prompt(openai_msgs)
+        # tinker_cookbook's renderer returns a ModelInput (multi-chunk). Flatten
+        # to a single list[int] — the exporter relies on this being contiguous.
+        if hasattr(out, "chunks"):
+            tokens: list[int] = []
+            for chunk in out.chunks:
+                chunk_tokens = getattr(chunk, "tokens", None)
+                if chunk_tokens is not None:
+                    tokens.extend(int(t) for t in chunk_tokens)
+            return tokens
+        return [int(t) for t in out]
+    return [
+        int(t)
+        for t in tokenizer.apply_chat_template(
+            openai_msgs, tokenize=True, add_generation_prompt=True,
+        )
+    ]
+
+
+async def _sample_one_llm_attempt(
+    *,
+    sampling_client: Any,
+    renderer: Any,
+    tokenizer: Any,
+    cfg: "OpenSpielTaskConfig",
+    turn_messages: list,
+    state: Any,
+    player: int,
+) -> tuple[int | None, list[int], list[int], list[float], str, float]:
+    """One sample -> parse attempt.
+
+    Shared by the regular sequential-turn loop and the simultaneous-move loop
+    so the two branches don't duplicate the build-prompt/submit/await/decode/
+    parse scaffolding (~50 LoC each).
+
+    Returns ``(action_or_None, prompt_tokens, sampled_tokens,
+    sampling_logprobs, response_text, timing_ms)``. ``action`` is validated
+    against the correct player's legal_actions (simultaneous games need the
+    player arg; sequential games default to the current player).
+    """
+    import asyncio as _aio
+    # Local import: the SDK adapter lives in weight_backends/; avoid paying
+    # the import cost at module load for non-Tinker callers.
+    from clawloop.weight_backends import _tinker_sdk
+    prompt_tokens = _build_generation_prompt_tokens(
+        renderer, tokenizer, turn_messages,
+    )
+    t0 = time.perf_counter()
+    fut = _tinker_sdk.async_sample(
+        sampling_client,
+        prompt_tokens=prompt_tokens,
+        num_samples=1,
+        max_tokens=cfg.max_tokens,
+        temperature=cfg.temperature,
+        top_p=cfg.top_p,
+    )
+    resp = await _aio.wrap_future(fut)
+    timing_ms = (time.perf_counter() - t0) * 1000.0
+    seq = resp.sequences[0]
+    sampled_tokens = list(seq.tokens)
+    # Logprobs are REQUIRED for the loss functions we use
+    # (``importance_sampling``, ``ppo``, ``cispo``, ``dro``).  A 0.0 fallback
+    # would mean log(1) = probability 1.0 → IS ratios of 1.0 → mathematically
+    # bogus training signal.  If Tinker's SamplingClient ever returns None
+    # we raise hard so the caller sees it rather than silent corruption.
+    if seq.logprobs is None:
+        raise RuntimeError(
+            "SamplingClient returned None for .logprobs; Tinker RL losses "
+            "(importance_sampling / ppo / cispo / dro) require real per-token "
+            "logprobs. If your workflow uses loss_fn='cross_entropy' (which "
+            "ignores logprobs), bypass this helper and build the Datum "
+            "without logprobs in loss_fn_inputs."
+        )
+    sampling_logprobs = list(seq.logprobs)
+    if len(sampled_tokens) != len(sampling_logprobs):
+        raise RuntimeError(
+            f"sampled_tokens/logprobs length mismatch: "
+            f"{len(sampled_tokens)} != {len(sampling_logprobs)}"
+        )
+    response_text = tokenizer.decode(sampled_tokens)
+    action = parse_move(response_text, state)
+    # Validate legality against the correct player (simultaneous vs sequential).
+    if action is not None:
+        legal = (
+            state.legal_actions(player)
+            if state.is_simultaneous_node()
+            else state.legal_actions()
+        )
+        if action not in legal:
+            action = None
+    return action, prompt_tokens, sampled_tokens, sampling_logprobs, response_text, timing_ms
+
+
+def _build_retry_hint(state: Any) -> str:
+    """Build a user-message hint shown after an illegal-move parse failure."""
+    # Simultaneous nodes return a sentinel (<0) from current_player(); the LLM
+    # always drives seat 0 in those cases. Also, simultaneous games need the
+    # per-player legal_actions(player) API — passing no arg raises on some
+    # games (matrix_mp).
+    raw = state.current_player()
+    player = raw if raw >= 0 else LLM_PID
+    legal = (
+        state.legal_actions(player)
+        if state.is_simultaneous_node()
+        else state.legal_actions()
+    )
+    legal_strs = [state.action_to_string(player, a) for a in legal]
+    return (
+        "Your previous response did not contain a legal move. "
+        f"Legal moves are: {', '.join(legal_strs)}. "
+        "Respond with exactly `Final Answer: <move>` where <move> is one of the listed legal moves."
+    )
+
+
+class OpenSpielTaskEnvironment:
+    """One game + one seed. Produces one Episode per run_episode() call."""
+
+    def __init__(self, config: OpenSpielTaskConfig, seed: int) -> None:
+        self._config = config
+        self._seed = seed
+
+    @property
+    def task_id(self) -> str:
+        return f"{self._config.game_name}_seed_{self._seed}"
+
+    @property
+    def seed(self) -> int:
+        return self._seed
+
+    @property
+    def config(self) -> OpenSpielTaskConfig:
+        return self._config
+
+    async def run_episode(
+        self, agent_state: Any, rollout_idx: int | None = None,
+    ):
+        """Roll out one OpenSpiel game, producing a ClawLoop Episode.
+
+        ``rollout_idx`` (optional) gives callers a reproducibility knob: when
+        supplied, each rollout in a GRPO group gets a deterministic-but-unique
+        RNG seed derived from ``(self._seed, rollout_idx)`` so chance outcomes
+        still diverge across the group (→ variance for GRPO) but the run as a
+        whole is reproducible. When ``None`` (the default), RNG is unseeded —
+        matches previous behavior for ad-hoc single-episode callers.
+
+        See module docstring for other design invariants.
+        """
+        import pyspiel
+        import numpy as np
+        from clawloop.core.episode import (
+            Episode, EpisodeSummary, Message, StepMeta, TokenLogProb,
+        )
+        from clawloop.core.reward import RewardSignal
+        from clawloop.weight_backends import _tinker_sdk
+
+        cfg = self._config
+        if rollout_idx is not None:
+            # Reproducible path: combine scenario seed and rollout index with
+            # a large multiplier so adjacent (seed, idx) pairs don't collide.
+            # Different idx → different chance outcomes → GRPO variance.
+            rng = np.random.default_rng(self._seed * 2654435761 + rollout_idx)
+        else:
+            # Unseeded path — keeps the previous fresh-RNG behavior for callers
+            # that don't care about reproducibility.
+            rng = np.random.default_rng()
+        game = pyspiel.load_game(cfg.game_name)
+        state = game.new_initial_state()
+
+        sampling_client = getattr(agent_state, "sampling_client", None)
+        if sampling_client is None:
+            raise RuntimeError(
+                "agent_state.sampling_client is None — wire TinkerWeightsBackend first"
+            )
+        renderer = getattr(agent_state, "renderer", None)
+        tokenizer = getattr(agent_state, "tokenizer", None)
+        if renderer is None or tokenizer is None:
+            raise RuntimeError(
+                "agent_state.renderer / tokenizer not set — learning_loop refresh missing (Task 15)"
+            )
+
+        llm_pid = LLM_PID
+        messages: list[Message] = []
+        steps: list[StepMeta] = []
+        illegal_parse = False
+        turn_idx = 0
+
+        while not state.is_terminal() and turn_idx < cfg.max_turns:
+            if state.is_chance_node():
+                outcomes = state.chance_outcomes()
+                actions = [a for a, _ in outcomes]
+                probs = np.array([p for _, p in outcomes], dtype=np.float64)
+                total = float(probs.sum())
+                probs = probs / total if total > 0 else probs
+                action = int(rng.choice(actions, p=probs))
+                state.apply_action(action)
+                continue
+
+            # Simultaneous-move games (matrix_mp, matching_pennies_3p).
+            # current_player == SIMULTANEOUS; every seat picks at once. The
+            # LLM picks for seat 0 via the usual prompt/sample/parse loop; all
+            # other seats use the opponent policy. Then state.apply_actions
+            # with the list of all players' actions advances the step.
+            if state.is_simultaneous_node():
+                # Sample LLM action for seat 0 below via the same retry loop,
+                # then collect random actions for seats 1..N-1.
+                n_players = state.num_players()
+                # Build actions[] for each seat; seat 0 comes from LLM.
+                seat_actions: list[int | None] = [None] * n_players
+                # Fill opponent seats first so we know if we're stuck.
+                for p in range(n_players):
+                    if p == llm_pid:
+                        continue
+                    assert cfg.opponent is not None, (
+                        f"{cfg.game_name} simultaneous node has seat {p} but no opponent"
+                    )
+                    # Some opponent implementations expose act_for_player;
+                    # fall back to act() for single-seat pollicies.
+                    if hasattr(cfg.opponent, "act_for_player"):
+                        seat_actions[p] = int(cfg.opponent.act_for_player(state, p))
+                    else:
+                        seat_actions[p] = int(cfg.opponent.act(state))
+                # Now LLM action for seat 0 — reuse the sampling loop below
+                # by faking current_player for the next block; handled
+                # specially by jumping into the shared LLM-turn branch.
+                # For clarity we inline a minimal version here.
+                prompt_str = build_prompt(state, messages, cfg.prompt_style)
+                turn_start = len(messages)
+                messages.append(Message(role="user", content=prompt_str))
+                resolved = False
+                llm_action: int | None = None
+                for attempt in range(cfg.rethink_k + 1):
+                    (action, prompt_tokens, sampled_tokens,
+                     sampling_logprobs, response_text, timing_ms) = (
+                        await _sample_one_llm_attempt(
+                            sampling_client=sampling_client,
+                            renderer=renderer, tokenizer=tokenizer,
+                            cfg=cfg, turn_messages=messages[turn_start:],
+                            state=state, player=llm_pid,
+                        )
+                    )
+                    assistant_msg = Message(
+                        role="assistant", content=response_text,
+                        logprobs=[TokenLogProb(token=str(t), logprob=float(lp))
+                                  for t, lp in zip(sampled_tokens, sampling_logprobs)],
+                    )
+                    if action is not None:
+                        messages.append(assistant_msg)
+                        steps.append(StepMeta(
+                            t=turn_idx, reward=0.0, done=False,
+                            timing_ms=timing_ms,
+                            info={
+                                "prompt_tokens": prompt_tokens,
+                                "sampled_tokens": sampled_tokens,
+                                "sampling_logprobs": sampling_logprobs,
+                                "legal_actions": list(state.legal_actions(llm_pid)),
+                                "chosen_action": int(action),
+                                "rethinks": attempt,
+                                "simultaneous": True,
+                            },
+                        ))
+                        llm_action = int(action)
+                        resolved = True
+                        break
+                    messages.append(assistant_msg)
+                    messages.append(Message(
+                        role="user", content=_build_retry_hint(state),
+                    ))
+                if not resolved:
+                    illegal_parse = True
+                    steps.append(StepMeta(
+                        t=turn_idx, reward=0.0, done=True, timing_ms=0.0,
+                        info={"illegal_after_retries": True, "simultaneous": True},
+                    ))
+                    break
+                seat_actions[llm_pid] = llm_action
+                state.apply_actions([int(a) for a in seat_actions])
+                turn_idx += 1
+                continue
+
+            current = state.current_player()
+            if current == llm_pid:
+                prompt_str = build_prompt(state, messages, cfg.prompt_style)
+                # Track the start of THIS turn's messages. For state-based
+                # OpenSpiel games the observation is Markovian, so we pass
+                # only the current turn (+ any retry pairs) to the renderer.
+                # Otherwise long games (2048 at 200 turns) blow past the
+                # model's context window.
+                turn_start = len(messages)
+                messages.append(Message(role="user", content=prompt_str))
+                resolved = False
+                for attempt in range(cfg.rethink_k + 1):
+                    (action, prompt_tokens, sampled_tokens,
+                     sampling_logprobs, response_text, timing_ms) = (
+                        await _sample_one_llm_attempt(
+                            sampling_client=sampling_client,
+                            renderer=renderer, tokenizer=tokenizer,
+                            cfg=cfg, turn_messages=messages[turn_start:],
+                            state=state, player=llm_pid,
+                        )
+                    )
+                    assistant_msg = Message(
+                        role="assistant", content=response_text,
+                        logprobs=[TokenLogProb(token=str(t), logprob=float(lp))
+                                  for t, lp in zip(sampled_tokens, sampling_logprobs)],
+                    )
+                    if action is not None:
+                        messages.append(assistant_msg)
+                        steps.append(StepMeta(
+                            t=turn_idx, reward=0.0, done=False,
+                            timing_ms=timing_ms,
+                            info={
+                                "prompt_tokens": prompt_tokens,
+                                "sampled_tokens": sampled_tokens,
+                                "sampling_logprobs": sampling_logprobs,
+                                "legal_actions": list(state.legal_actions()),
+                                "chosen_action": int(action),
+                                "rethinks": attempt,
+                            },
+                        ))
+                        state.apply_action(int(action))
+                        resolved = True
+                        break
+                    # Illegal: append rejected response + retry hint and try again.
+                    messages.append(assistant_msg)
+                    messages.append(Message(
+                        role="user", content=_build_retry_hint(state),
+                    ))
+
+                if not resolved:
+                    illegal_parse = True
+                    steps.append(StepMeta(
+                        t=turn_idx, reward=0.0, done=True, timing_ms=0.0,
+                        info={"illegal_after_retries": True},
+                    ))
+                    break
+            else:
+                assert cfg.opponent is not None, (
+                    f"{cfg.game_name} has non-LLM player {current} but no opponent configured"
+                )
+                action = int(cfg.opponent.act(state))
+                state.apply_action(action)
+            turn_idx += 1
+
+        # Termination — attach final reward to the last StepMeta.
+        if state.is_terminal():
+            final_reward = float(state.returns()[llm_pid])
+        else:
+            final_reward = 0.0
+        if steps:
+            last = steps[-1]
+            steps[-1] = dc_replace(last, reward=final_reward, done=True)
+
+        signals = {
+            "outcome": RewardSignal(
+                name="outcome", value=final_reward, confidence=1.0,
+            ),
+        }
+        if illegal_parse:
+            signals["illegal_parse"] = RewardSignal(
+                name="illegal_parse", value=1.0, confidence=1.0,
+            )
+
+        summary = EpisodeSummary(signals=signals)
+
+        return Episode(
+            id=Episode.new_id(),
+            state_id=agent_state.state_id().combined_hash if hasattr(agent_state, "state_id") else "",
+            task_id=self.task_id,
+            bench="openspiel",
+            messages=messages,
+            step_boundaries=[],
+            steps=steps,
+            summary=summary,
+        )
+
+
+class OpenSpielGameAdapter:
+    """Dispatches run_episode(task_id, agent_state) to the per-seed env.
+
+    Implements the AdapterLike protocol with a SYNC run_episode; the per-seed
+    env's async run_episode is executed under an event loop via
+    :func:`clawloop.utils.async_bridge.run_async` (same pattern as
+    :class:`~clawloop.environments.harbor.HarborAdapter`).
+    """
+
+    def __init__(self, envs_by_task_id: dict[str, OpenSpielTaskEnvironment]) -> None:
+        self._envs_by_task_id = envs_by_task_id
+
+    def run_episode(self, task_id: str, agent_state: Any):
+        from clawloop.utils.async_bridge import run_async
+        env = self._envs_by_task_id[task_id]
+        return run_async(env.run_episode(agent_state))
+
+    @staticmethod
+    def _make_error_episode(task_id: str, exc: BaseException):
+        """Stub Episode for a failed rollout — preserves batch cardinality
+        so GRPO grouping stays sane; carries the error on signals / metadata
+        so the logger can surface per-iter failure rates.
+        """
+        from clawloop.core.episode import Episode, EpisodeSummary
+        from clawloop.core.reward import RewardSignal
+        summary = EpisodeSummary(signals={
+            "outcome": RewardSignal(name="outcome", value=0.0, confidence=1.0),
+            "rollout_error": RewardSignal(name="rollout_error", value=1.0, confidence=1.0),
+        })
+        return Episode(
+            id=Episode.new_id(),
+            state_id="",
+            task_id=task_id,
+            bench="openspiel",
+            messages=[],
+            step_boundaries=[],
+            steps=[],
+            summary=summary,
+            metadata={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    async def run_episodes_batch_async(
+        self, task_ids: list[str], agent_state: Any,
+    ) -> list:
+        """Async rollout of many episodes concurrently.
+
+        Call this from an existing event loop (Streamlit, FastAPI, another
+        asyncio coroutine). For the common synchronous driver (ClawLoop's
+        :func:`~clawloop.core.loop.learning_loop`) use :meth:`run_episodes_batch`
+        which wraps this one.
+
+        Tinker's :class:`SamplingClient.sample` returns a ``ConcurrentFuture``
+        so N in-flight requests run in parallel up to the account's quota.
+        Our per-episode loop is sequential (turns are causally dependent)
+        but across episodes we gain an N× speedup — this turns a ~1h
+        serial mixed-game iter into ~10 min.
+
+        Each ``task_id`` entry maps to one episode. Duplicates are allowed
+        (GRPO needs K rollouts per same scenario) — each rollout gets the
+        enumeration index as its ``rollout_idx``, so chance outcomes
+        diverge while remaining reproducible across runs.
+        """
+        import asyncio
+
+        coros = [
+            self._envs_by_task_id[tid].run_episode(
+                agent_state, rollout_idx=i,
+            )
+            for i, tid in enumerate(task_ids)
+        ]
+        # return_exceptions=True isolates per-episode failures — one
+        # transient Tinker sampling error shouldn't abort a 32-episode
+        # iter. Failing episodes are replaced with a stub Episode that
+        # carries the error on its summary signals so downstream logging
+        # can surface the rate without breaking the training loop.
+        results = await asyncio.gather(*coros, return_exceptions=True)
+        out: list = []
+        for task_id, res in zip(task_ids, results):
+            if isinstance(res, BaseException):
+                out.append(self._make_error_episode(task_id, res))
+            else:
+                out.append(res)
+        return out
+
+    def run_episodes_batch(
+        self, task_ids: list[str], agent_state: Any,
+    ) -> list:
+        """Synchronous wrapper around :meth:`run_episodes_batch_async`.
+
+        Spins up a fresh event loop via ``asyncio.run``. Refuses to be
+        called from an already-running event loop — use
+        :meth:`run_episodes_batch_async` instead in that case.
+        """
+        import asyncio
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(
+                self.run_episodes_batch_async(task_ids, agent_state)
+            )
+        raise RuntimeError(
+            "run_episodes_batch cannot be called from inside a running event "
+            "loop — use run_episodes_batch_async instead."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Prompt-building / move-parsing helpers (Task 12).
+#
+# Pure functions: no network, no SDK state. Task 13's per-turn loop uses these.
+# Strategy: prefer game_arena's harness primitives when available; fall back
+# to OpenSpiel-native state/legal-action strings otherwise. Both paths share
+# the same input/output shapes so callers stay agnostic.
+# ---------------------------------------------------------------------------
+
+
+def _state_observation(state: Any, player: int) -> str:
+    """Return a human-readable state string, trying the methods OpenSpiel
+    games implement in varying combinations. sheriff lacks
+    ``observation_string`` (has ``information_state_string``); hanabi / maedn
+    lack ``information_state_string`` (have ``observation_string``). Every
+    game implements ``str(state)`` as a safe last resort."""
+    for fn_name in ("observation_string", "information_state_string"):
+        fn = getattr(state, fn_name, None)
+        if fn is None:
+            continue
+        try:
+            return fn(player)
+        except Exception:
+            continue
+    return str(state)
+
+
+def _prompt_fallback(state: Any, history: list, style: str) -> str:
+    """OpenSpiel-native prompt. Works for 1P / chance / 2P / multi-player alike."""
+    import pyspiel as _py
+    # For simultaneous nodes, current_player() returns a sentinel — the LLM
+    # always takes seat 0 in that case (we drive all non-LLM seats via
+    # opponent policy, so seat 0's observation is what we render).
+    raw = state.current_player()
+    player = raw if raw >= 0 else 0
+    observation = _state_observation(state, player)
+    legal = (
+        state.legal_actions(player)
+        if state.is_simultaneous_node()
+        else state.legal_actions()
+    )
+    legal_strs = [state.action_to_string(player, a) for a in legal]
+    lines = [
+        f"You are player {player}.",
+        "Current game state:",
+        observation,
+        "",
+        f"Your legal moves: {', '.join(legal_strs)}",
+        "",
+        "Respond with your chosen move wrapped as `Final Answer: <move>`.",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_move_fallback(response: str, state: Any) -> int | None:
+    """Extract a legal action from free-form text. Returns action int or None.
+
+    Strategy:
+    1. Prefer `Final Answer: <move>` form.
+    2. Longest-match the candidate against legal action strings (case-insensitive).
+    3. If still no match, scan the whole response for any legal action string.
+    """
+    raw = state.current_player()
+    player = raw if raw >= 0 else 0
+    legal = (
+        state.legal_actions(player)
+        if state.is_simultaneous_node()
+        else state.legal_actions()
+    )
+    legal_strs = [(a, state.action_to_string(player, a)) for a in legal]
+
+    m = re.search(
+        r"Final Answer\s*[:\-]\s*(.+?)(?:$|\n|[.!,])",
+        response,
+        flags=re.IGNORECASE,
+    )
+    candidate = m.group(1).strip() if m else response
+    candidate_lower = candidate.lower()
+
+    # Longest-match among legal action strings within the candidate segment.
+    best: tuple[int, int] | None = None   # (length, action)
+    for a, s in legal_strs:
+        s_lower = s.lower()
+        if s_lower and s_lower in candidate_lower:
+            if best is None or len(s_lower) > best[0]:
+                best = (len(s_lower), a)
+    if best is not None:
+        return best[1]
+
+    # Whole-response fallback.
+    response_lower = response.lower()
+    for a, s in legal_strs:
+        if s.lower() and s.lower() in response_lower:
+            return a
+    return None
+
+
+def _prompt_via_game_arena(state: Any, history: list, style: str) -> str | None:
+    """Try game_arena's prompt_generation. Return None if unsupported for this game."""
+    try:
+        from game_arena.harness import prompt_generation  # type: ignore[import-not-found]
+    except Exception:
+        return None
+    try:
+        # game_arena 0.x: build(state=..., style=..., history=...) — signature may
+        # vary across pin; wrap in try/except to gracefully fall back.
+        return prompt_generation.build(state=state, style=style, history=history)
+    except Exception:
+        return None
+
+
+def build_prompt(state: Any, history: list, style: str) -> str:
+    """Prefer game_arena; fall back to OpenSpiel-native."""
+    return _prompt_via_game_arena(state, history, style) or _prompt_fallback(state, history, style)
+
+
+def parse_move(response: str, state: Any) -> int | None:
+    """Prefer game_arena parser; fall back to regex-over-legal-strings."""
+    try:
+        from game_arena.harness import parsers  # type: ignore[import-not-found]
+    except Exception:
+        return _parse_move_fallback(response, state)
+
+    try:
+        action = parsers.parse_move(response, state.legal_actions())
+        if action is not None:
+            return int(action)
+    except Exception:
+        pass
+    return _parse_move_fallback(response, state)

--- a/clawloop/train.py
+++ b/clawloop/train.py
@@ -56,16 +56,22 @@ class TrainConfig(BaseModel):
 
     mode: Literal["weight", "harness_learning", "full"]
     env_type: str = "harbor"
+    weight_backend: Literal["skyrl", "tinker"] = "skyrl"
 
     llm_clients: dict[str, LLMClientConfig] = {}
     skyrl: dict[str, Any] | None = None
+    tinker: dict[str, Any] | None = None
     harbor: HarborConfig | None = None
+    openspiel: dict[str, Any] | None = None
     env_config: dict[str, Any] | None = None
 
     system_prompt: str = "You are a helpful assistant."
     benches: list[str] = ["default"]
     episodes_per_iter: int = 10
     n_iterations: int = 100
+    output_dir: str | Path | None = None
+    wandb_project: str | None = None    # if set, mirrors metrics to wandb (requires WANDB_API_KEY)
+    wandb_name: str | None = None       # optional wandb run name; defaults to output_dir basename
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -171,17 +177,122 @@ def _build_openclaw(
 # Environment registry — add new envs here
 # ---------------------------------------------------------------------------
 
+def _build_openspiel(config: "TrainConfig", llm_clients: dict[str, "LLMClientConfig"]):
+    """Build a ClawLoop adapter over one or more OpenSpiel games.
+
+    Two config shapes are accepted:
+
+    1. **Single game (legacy)** — ``openspiel`` is a flat dict with
+       ``game_name, seeds, episodes_per_seed, ...`` fields. All knobs apply to
+       that single game.
+
+    2. **Mixed-game** — ``openspiel`` has a ``games`` list; each entry is a
+       per-game dict that can override ``max_turns`` / ``max_tokens`` etc.
+       Shared sampling knobs (``prompt_style``, ``temperature``, ``top_p``)
+       can live at the top level and are inherited by each game unless the
+       per-game dict overrides them. Episodes from all games land in one
+       ``forward_backward`` batch; GRPO still groups per-scenario via
+       ``task_id = f"{game}_seed_{seed}"``.
+    """
+    from clawloop.environments.openspiel import (
+        OpenSpielGameAdapter,
+        OpenSpielTaskConfig,
+        OpenSpielTaskEnvironment,
+        _resolve_opponent,
+    )
+
+    raw = dict(config.openspiel or {})
+
+    if "games" in raw:
+        games_specs = list(raw.pop("games"))
+        shared = raw  # remaining keys act as defaults for every game
+        envs_by_task_id: dict[str, OpenSpielTaskEnvironment] = {}
+        tasks: list[str] = []
+        for spec in games_specs:
+            game_raw = {**shared, **dict(spec)}  # per-game overrides win
+            epk = int(game_raw.pop("episodes_per_seed", 4))
+            if "opponent" in game_raw:
+                game_raw["opponent"] = _resolve_opponent(game_raw["opponent"])
+            cfg = OpenSpielTaskConfig(**game_raw)
+            for s in cfg.seeds:
+                tid = f"{cfg.game_name}_seed_{s}"
+                envs_by_task_id[tid] = OpenSpielTaskEnvironment(cfg, seed=s)
+                tasks.extend([tid] * epk)
+        return OpenSpielGameAdapter(envs_by_task_id), tasks
+
+    # Legacy single-game path.
+    episodes_per_seed = int(raw.pop("episodes_per_seed", 4))
+    cfg = OpenSpielTaskConfig(**raw)
+    envs_by_task_id = {
+        f"{cfg.game_name}_seed_{s}": OpenSpielTaskEnvironment(cfg, seed=s)
+        for s in cfg.seeds
+    }
+    tasks = [tid for tid in envs_by_task_id for _ in range(episodes_per_seed)]
+    return OpenSpielGameAdapter(envs_by_task_id), tasks
+
+
 ENV_BUILDERS: dict[str, Any] = {
     "harbor": _build_harbor,
     "math": _build_math,
     "entropic": _build_entropic,
     "openclaw": _build_openclaw,
+    "openspiel": _build_openspiel,
 }
 
 
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
+
+def effective_episodes_per_iter(config: TrainConfig) -> int:
+    """Derive the actual episodes-per-iter without mutating the config.
+
+    For ``env_type='openspiel'`` the count is determined by the seed pools
+    and ``episodes_per_seed`` knob (single-game or per-game list); for every
+    other env_type we honor ``config.episodes_per_iter`` as supplied.
+
+    Keeping this pure makes :func:`validate_config` non-mutating and lets
+    callers compute the value consistently at construction time.
+    """
+    if config.env_type != "openspiel" or not config.openspiel:
+        return config.episodes_per_iter
+    osp = config.openspiel
+
+    def _check_positive(k: int, label: str) -> int:
+        if k <= 0:
+            raise ValueError(f"{label} must be a positive int (got {k})")
+        return k
+
+    def _check_seeds(seeds: Any, label: str) -> list:
+        if not isinstance(seeds, (list, tuple)):
+            raise ValueError(
+                f"{label} must be a list/tuple (got {type(seeds).__name__})"
+            )
+        if len(seeds) == 0:
+            raise ValueError(f"{label} must be non-empty")
+        return list(seeds)
+
+    if "games" in osp:
+        total = 0
+        shared_k = _check_positive(
+            int(osp.get("episodes_per_seed", 4)),
+            "openspiel.episodes_per_seed",
+        )
+        for i, g in enumerate(osp["games"]):
+            seeds = _check_seeds(g.get("seeds"), f"openspiel.games[{i}].seeds")
+            k = _check_positive(
+                int(g.get("episodes_per_seed", shared_k)),
+                f"openspiel.games[{i}].episodes_per_seed",
+            )
+            total += len(seeds) * k
+        return total
+    seeds = _check_seeds(osp.get("seeds"), "openspiel.seeds")
+    k = _check_positive(
+        int(osp.get("episodes_per_seed", 4)),
+        "openspiel.episodes_per_seed",
+    )
+    return len(seeds) * k
+
 
 def validate_config(config: TrainConfig) -> list[str]:
     """Validate config consistency. Returns the active layers list."""
@@ -195,8 +306,15 @@ def validate_config(config: TrainConfig) -> list[str]:
 
     layers = MODE_LAYERS[config.mode]
 
-    if "weights" in layers and not config.skyrl:
-        raise ValueError(f"mode='{config.mode}' requires 'skyrl' config for weight training")
+    if "weights" in layers:
+        if config.weight_backend == "tinker" and not config.tinker:
+            raise ValueError(
+                f"mode='{config.mode}' with weight_backend='tinker' requires 'tinker' config"
+            )
+        if config.weight_backend == "skyrl" and not config.skyrl:
+            raise ValueError(
+                f"mode='{config.mode}' with weight_backend='skyrl' requires 'skyrl' config"
+            )
 
     if "harness" in layers and "reflector" not in config.llm_clients:
         raise ValueError(f"mode='{config.mode}' requires 'reflector' in llm_clients")
@@ -217,6 +335,37 @@ def validate_config(config: TrainConfig) -> list[str]:
     if config.env_type == "entropic":
         if not config.env_config:
             raise ValueError("entropic env requires 'env_config'")
+    if config.env_type == "openspiel":
+        # OpenSpielTaskEnvironment.run_episode reads sampling_client /
+        # renderer / tokenizer off AgentState — those are only populated
+        # by TinkerWeightsBackend's per-iter refresh hooks. Any other
+        # weight_backend would fail at runtime with a non-obvious
+        # RuntimeError; fail fast here with a clear message.
+        if config.weight_backend != "tinker":
+            raise ValueError(
+                f"env_type='openspiel' currently requires weight_backend='tinker' "
+                f"(got {config.weight_backend!r}) — the OpenSpiel env consumes "
+                f"Tinker's SamplingClient directly. Self-hosted sampling is a "
+                f"follow-up."
+            )
+        if not config.openspiel:
+            raise ValueError("openspiel env requires 'openspiel' config")
+        if "games" in config.openspiel:
+            games = config.openspiel["games"]
+            if not games:
+                raise ValueError("openspiel.games must be a non-empty list")
+            for i, g in enumerate(games):
+                if not g.get("game_name"):
+                    raise ValueError(f"openspiel.games[{i}].game_name required")
+                if not g.get("seeds"):
+                    raise ValueError(f"openspiel.games[{i}].seeds must be non-empty")
+        else:
+            if not config.openspiel.get("seeds"):
+                raise ValueError("openspiel.seeds must be a non-empty list")
+            if not config.openspiel.get("game_name"):
+                raise ValueError("openspiel.game_name required")
+        # episodes_per_iter is derived from the openspiel spec at train() time
+        # via effective_episodes_per_iter(); we do NOT mutate config here.
 
     return layers
 
@@ -258,11 +407,24 @@ def train(config: TrainConfig):
     # 2. Weights backend
     backend = None
     if "weights" in layers:
-        from clawloop.weight_backends.skyrl import SkyRLWeightsBackend, SkyRLWeightsConfig
+        if config.weight_backend == "tinker":
+            from clawloop.weight_backends.tinker import (
+                TinkerWeightsBackend,
+                TinkerWeightsConfig,
+            )
 
-        skyrl_cfg = SkyRLWeightsConfig(**config.skyrl)
-        backend = SkyRLWeightsBackend(skyrl_cfg)
-        weights = Weights(model_ref=skyrl_cfg.base_model, _backend=backend)
+            tinker_cfg = TinkerWeightsConfig(**config.tinker)
+            backend = TinkerWeightsBackend(tinker_cfg)
+            weights = Weights(model_ref=tinker_cfg.base_model, _backend=backend)
+        else:  # skyrl (existing default)
+            from clawloop.weight_backends.skyrl import (
+                SkyRLWeightsBackend,
+                SkyRLWeightsConfig,
+            )
+
+            skyrl_cfg = SkyRLWeightsConfig(**config.skyrl)
+            backend = SkyRLWeightsBackend(skyrl_cfg)
+            weights = Weights(model_ref=skyrl_cfg.base_model, _backend=backend)
     else:
         weights = Weights()
 
@@ -289,8 +451,11 @@ def train(config: TrainConfig):
         adapter=adapter,
         agent_state=agent_state,
         tasks=tasks,
-        n_episodes=config.episodes_per_iter,
+        n_episodes=effective_episodes_per_iter(config),
         n_iterations=config.n_iterations,
         active_layers=layers,
         intensity=AdaptiveIntensity() if "harness" in layers else None,
+        output_dir=config.output_dir,
+        wandb_project=config.wandb_project,
+        wandb_name=config.wandb_name,
     )

--- a/clawloop/weight_backends/_tinker_exporter.py
+++ b/clawloop/weight_backends/_tinker_exporter.py
@@ -1,0 +1,132 @@
+"""Episode -> Tinker ``Datum`` exporter with episode-level GRPO advantages.
+
+Algorithm
+---------
+1. Group input episodes by ``Episode.task_id``.
+2. For each group with N >= 2 and non-zero reward variance, compute
+   ``advantage[ep] = reward(ep) - mean(rewards in group)``.  Singleton
+   groups and zero-variance groups are dropped (no gradient signal).
+3. For each surviving episode, emit one :class:`tinker.Datum` per LLM
+   turn.  An LLM turn is a step whose ``StepMeta.info`` carries the
+   exact-token alignment payload written by the SamplingClient at
+   sampling time:
+
+   - ``prompt_tokens``: ``list[int]`` — exact prompt tokens the
+     SamplingClient saw.
+   - ``sampled_tokens``: ``list[int]`` — exact tokens it emitted.
+   - ``sampling_logprobs``: ``list[float]`` — per-token logprobs,
+     aligned 1:1 with ``sampled_tokens``.
+
+   Steps lacking ``prompt_tokens`` are non-LLM (CHANCE / opponent) and
+   are skipped.
+
+The exporter does **not** re-tokenize assistant text — chat-template
+markers, role headers, and whitespace do not round-trip deterministically
+through tokenizers, so we rely on the persisted token IDs as ground truth.
+
+Reward attribute note
+---------------------
+``EpisodeSummary`` does not expose a ``.reward`` attribute.  The canonical
+internal reward space is [-1, 1], reachable via
+:meth:`EpisodeSummary.effective_reward`.  We use that here (matches the
+project's "canonical [-1, 1] internal" convention).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+from tinker import types as tinker_types
+
+from clawloop.core.episode import Episode
+
+__all__ = ["episodes_to_tinker_datums"]
+
+
+def _episode_return(ep: Episode) -> float:
+    """Total return for one episode in canonical [-1, 1] space."""
+    return ep.summary.effective_reward()
+
+
+def episodes_to_tinker_datums(
+    episodes: list[Episode],
+    *,
+    loss_fn: str,  # noqa: ARG001 — accepted for future use (e.g., losses
+    # that ignore logprobs); v1 does not branch on it.
+) -> list[tinker_types.Datum]:
+    """Convert episodes into Tinker training data with GRPO advantages.
+
+    See module docstring for the full algorithm.  Returns an empty list
+    when every group is filtered (singleton or zero-variance).
+    """
+    # 1. Group by task_id — but exclude episodes carrying a rollout_error
+    # signal (from OpenSpielGameAdapter's per-episode failure isolation).
+    # Their outcome value is a neutral 0.0 and would taint the group baseline
+    # if we let them in. Their `.steps` is empty too, so they'd emit zero
+    # datums anyway — filtering here just keeps the baseline clean.
+    by_task: dict[str, list[Episode]] = defaultdict(list)
+    for ep in episodes:
+        if ep.summary.signals and ep.summary.signals.get("rollout_error"):
+            continue
+        by_task[ep.task_id].append(ep)
+
+    # 2. Compute episode-level advantages for surviving groups.
+    advantage_by_id: dict[int, float] = {}
+    for group in by_task.values():
+        if len(group) < 2:
+            continue
+        returns = [_episode_return(ep) for ep in group]
+        if max(returns) == min(returns):
+            continue  # zero variance — no gradient signal
+        mean_return = sum(returns) / len(returns)
+        for ep, r in zip(group, returns, strict=True):
+            advantage_by_id[id(ep)] = r - mean_return
+
+    # 3. Emit one Datum per LLM turn.
+    datums: list[tinker_types.Datum] = []
+    for ep in episodes:
+        adv = advantage_by_id.get(id(ep))
+        if adv is None:
+            continue
+        for step in ep.steps:
+            info = step.info
+            if "prompt_tokens" not in info:
+                continue  # non-LLM step (CHANCE / opponent) — skip
+
+            prompt_tokens = list(info["prompt_tokens"])
+            sampled_tokens = list(info["sampled_tokens"])
+            sampling_logprobs = list(info["sampling_logprobs"])
+
+            if len(sampled_tokens) != len(sampling_logprobs):
+                raise ValueError(
+                    "alignment invariant violated: "
+                    f"len(sampled_tokens)={len(sampled_tokens)} != "
+                    f"len(sampling_logprobs)={len(sampling_logprobs)} "
+                    f"on episode {ep.id} step {step.t}"
+                )
+            if len(sampled_tokens) == 0:
+                continue  # empty completion — nothing to learn from
+
+            n_prompt = len(prompt_tokens)
+            n_comp = len(sampled_tokens)
+            full_tokens = prompt_tokens + sampled_tokens
+            target_tokens = [0] * n_prompt + sampled_tokens
+            logprobs_arr = [0.0] * n_prompt + sampling_logprobs
+            advantages_arr = [0.0] * n_prompt + [adv] * n_comp
+
+            datums.append(
+                tinker_types.Datum(
+                    model_input=tinker_types.ModelInput(
+                        chunks=[
+                            tinker_types.EncodedTextChunk(tokens=full_tokens),
+                        ],
+                    ),
+                    loss_fn_inputs={
+                        "target_tokens": np.asarray(target_tokens, dtype=np.int64),
+                        "logprobs": np.asarray(logprobs_arr, dtype=np.float32),
+                        "advantages": np.asarray(advantages_arr, dtype=np.float32),
+                    },
+                )
+            )
+    return datums

--- a/clawloop/weight_backends/_tinker_sdk.py
+++ b/clawloop/weight_backends/_tinker_sdk.py
@@ -1,0 +1,330 @@
+"""Thin adapter over the Tinker SDK.
+
+Every Tinker SDK call lives behind a typed function in this module so SDK
+drift is isolated to a single file.  Tinker exceptions are translated
+(by exception-class name, not isinstance — so we survive SDK version
+shuffles) into :class:`TinkerBackendError`, which wraps the ClawLoop
+:class:`BackendError` dataclass with the correct ``recoverable`` bit.
+
+Signatures verified against ``tinker==0.18.1`` (preflight Task 2).
+
+Notes on design
+---------------
+- ``BackendError`` in ``clawloop.weight_backends.base`` is a frozen dataclass
+  (not an ``Exception``); it cannot be raised.  We therefore expose
+  ``TinkerBackendError(Exception)`` which carries a ``BackendError`` on
+  ``.error`` and mirrors ``recoverable``/``code``/``message`` as properties
+  for ergonomic use at call sites.
+
+- Futures (``ConcurrentFuture``) returned by ``async_sample`` and
+  ``forward_backward`` are passed through unchanged so callers can submit
+  multiple operations before awaiting any of them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import tinker
+from tinker import types as _tinker_types
+
+from clawloop.weight_backends.base import BackendError
+
+
+# ---------------------------------------------------------------------------
+# Exception wrapper
+# ---------------------------------------------------------------------------
+
+class TinkerBackendError(Exception):
+    """Raisable wrapper around a :class:`BackendError` descriptor.
+
+    Exposes the underlying dataclass on ``.error`` and mirrors its
+    ``recoverable``/``code``/``message`` fields as properties so callers can
+    write ``except TinkerBackendError as e: if e.recoverable: ...`` without
+    reaching into ``.error`` every time.
+    """
+
+    def __init__(self, error: BackendError) -> None:
+        self.error = error
+        super().__init__(f"[{error.code}] {error.message}")
+
+    @property
+    def recoverable(self) -> bool:
+        return self.error.recoverable
+
+    @property
+    def code(self) -> str:
+        return self.error.code
+
+    @property
+    def message(self) -> str:
+        return self.error.message
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy
+# ---------------------------------------------------------------------------
+
+# Single source of truth: ``exc_name -> (code, recoverable)``. Matching is on
+# ``type(exc).__name__`` (string) rather than ``isinstance`` so we survive SDK
+# version shuffles where the class might live at a different import path but
+# keep the same name. Unknown names fall through to ``("unknown", False)``
+# (conservative — prefer fail-loud over silent retry on a genuinely broken call).
+#
+# Edit this table when the SDK adds new exception types.
+_ERROR_TAXONOMY: dict[str, tuple[str, bool]] = {
+    # Recoverable
+    "RateLimitError":             ("backend_unreachable", True),
+    "APIConnectionError":         ("backend_unreachable", True),
+    "APITimeoutError":            ("backend_unreachable", True),
+    "InternalServerError":        ("backend_unreachable", True),
+    "RequestFailedError":         ("backend_unreachable", True),
+    # Non-recoverable
+    "BadRequestError":            ("invalid_config", False),
+    "AuthenticationError":        ("invalid_config", False),
+    "PermissionDeniedError":      ("invalid_config", False),
+    "UnprocessableEntityError":   ("invalid_config", False),
+    "ConflictError":              ("invalid_config", False),
+    "APIResponseValidationError": ("schema_incompatible", False),
+}
+
+
+def _wrap(exc: Exception) -> TinkerBackendError:
+    """Translate a raw Tinker exception into a :class:`TinkerBackendError`."""
+    name = type(exc).__name__
+    code, recoverable = _ERROR_TAXONOMY.get(name, ("unknown", False))
+    return TinkerBackendError(
+        BackendError(code=code, message=str(exc), recoverable=recoverable)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thin adapter functions
+# ---------------------------------------------------------------------------
+
+def make_service_client() -> "tinker.ServiceClient":
+    """Return a new Tinker :class:`ServiceClient`.
+
+    Reads ``TINKER_API_KEY`` from the environment; no kwargs are passed.
+    """
+    try:
+        return tinker.ServiceClient()
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def create_training(
+    service: "tinker.ServiceClient",
+    *,
+    base_model: str,
+    rank: int,
+    seed: int,
+    train_attn: bool,
+    train_mlp: bool,
+    train_unembed: bool,
+) -> Any:
+    """Create a LoRA training client on *service*.
+
+    All six kwargs are forwarded to ``service.create_lora_training_client``.
+    There is NO ``alpha`` kwarg in tinker 0.18.1.
+    """
+    try:
+        return service.create_lora_training_client(
+            base_model=base_model,
+            rank=rank,
+            seed=seed,
+            train_attn=train_attn,
+            train_mlp=train_mlp,
+            train_unembed=train_unembed,
+        )
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def create_sampling(
+    service: "tinker.ServiceClient",
+    *,
+    base_model: str | None = None,
+    model_path: str | None = None,
+    retry_config: Any = None,
+) -> Any:
+    """Create a sampling client.
+
+    Exactly one of ``base_model`` or ``model_path`` must be supplied.
+    Passing both or neither raises :class:`ValueError`.
+    """
+    if (base_model is None) == (model_path is None):
+        raise ValueError(
+            "exactly one of base_model or model_path is required"
+        )
+    kwargs: dict[str, Any] = {"retry_config": retry_config}
+    if base_model is not None:
+        kwargs["base_model"] = base_model
+    else:
+        kwargs["model_path"] = model_path
+    try:
+        return service.create_sampling_client(**kwargs)
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def async_sample(
+    sampling_client: Any,
+    *,
+    prompt_tokens: list[int],
+    num_samples: int = 1,
+    max_tokens: int = 128,
+    temperature: float = 1.0,
+    top_p: float = 0.95,
+    stop: list[int] | None = None,
+) -> Any:
+    """Submit a sampling request and return the ``ConcurrentFuture`` unchanged.
+
+    The caller can submit several sampling ops before awaiting any of them.
+    """
+    try:
+        prompt = _tinker_types.ModelInput(
+            chunks=[_tinker_types.EncodedTextChunk(tokens=prompt_tokens)]
+        )
+        params = _tinker_types.SamplingParams(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            stop=stop,
+        )
+        return sampling_client.sample(
+            prompt=prompt,
+            num_samples=num_samples,
+            sampling_params=params,
+        )
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def forward_backward(
+    training: Any,
+    batch: list,
+    *,
+    loss_fn: str,
+    loss_fn_config: dict | None = None,
+) -> Any:
+    """Submit a forward_backward op; return the future so callers can pipeline."""
+    try:
+        return training.forward_backward(
+            data=batch,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+        )
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def optim_step(training: Any, adam_params: "_tinker_types.AdamParams") -> Any:
+    """Apply an optimizer step with a typed :class:`AdamParams` object.
+
+    Tinker 0.18.1 takes the typed object positionally — **not** a dict,
+    **not** loose kwargs.
+    """
+    try:
+        return training.optim_step(adam_params)
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def save_weights_and_get_sampling_client(
+    training: Any,
+    name: str,
+    *,
+    retry_config: Any = None,
+) -> Any:
+    """Persist a checkpoint and return the fresh :class:`SamplingClient`.
+
+    The SDK returns the client directly — no tuple, no ttl.
+    """
+    try:
+        return training.save_weights_and_get_sampling_client(
+            name, retry_config=retry_config
+        )
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def save_state_durable(
+    training: Any, name: str, *, ttl_seconds: int | None = None,
+) -> str | None:
+    """Write a durable training checkpoint; return its ``tinker://`` path.
+
+    Unlike :func:`save_weights_and_get_sampling_client` (ephemeral — its ``name``
+    is ignored, no enumerable path), ``save_state`` produces a checkpoint that
+    :func:`list_checkpoints` can find and that ``create_training_client_from_state``
+    can re-attach to.  We call both per iteration: one for the fresh
+    SamplingClient next iter will use, one for audit/resume.
+    """
+    try:
+        fut = training.save_state(name, ttl_seconds=ttl_seconds)
+        resp = fut.result()
+        return getattr(resp, "path", None) or getattr(resp, "tinker_path", None)
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def get_model_id(training: Any) -> str:
+    """Training-run identifier used by :func:`list_checkpoints`."""
+    try:
+        return training.model_id
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def make_rest_client(service: Any) -> Any:
+    try:
+        return service.create_rest_client()
+    except Exception as e:
+        raise _wrap(e) from e
+
+
+def list_checkpoints(rest: Any, training_run_id: str) -> list[dict[str, Any]]:
+    """Return a JSON-serializable snapshot of the run's current checkpoints.
+
+    Each entry is ``{"checkpoint_id", "checkpoint_type", "time", "tinker_path",
+    "size_bytes", "expires_at", "public"}``.  Best-effort — never raises the
+    run; on SDK failure returns ``[{"error": ...}]`` so the caller can still log.
+    """
+    try:
+        fut = rest.list_checkpoints(training_run_id)
+        resp = fut.result()
+    except Exception as e:
+        return [{"error": type(e).__name__, "message": str(e)}]
+
+    def _coerce(v: Any) -> Any:
+        if v is None or isinstance(v, (str, int, float, bool)):
+            return v
+        # datetime.datetime -> ISO 8601; pydantic enums / objects -> str.
+        return str(v)
+
+    out: list[dict[str, Any]] = []
+    for ck in getattr(resp, "checkpoints", []) or []:
+        out.append({
+            "checkpoint_id":   _coerce(getattr(ck, "checkpoint_id", None)),
+            "checkpoint_type": _coerce(getattr(ck, "checkpoint_type", None)),
+            "time":            _coerce(getattr(ck, "time", None)),
+            "tinker_path":     _coerce(getattr(ck, "tinker_path", None)),
+            "size_bytes":      getattr(ck, "size_bytes", None),
+            "expires_at":      _coerce(getattr(ck, "expires_at", None)),
+            "public":          getattr(ck, "public", None),
+        })
+    return out
+
+
+def load_state_with_optimizer(training: Any, path: str) -> Any:
+    """Restore weights + optimizer state from ``path`` (``tinker://...`` URI).
+
+    Returns whatever the SDK returns (likely an ``APIFuture``; await before
+    use). Use this — not the weights-only ``load_state`` — when you need
+    optimizer momentum/variance restored on resume.
+    """
+    try:
+        fut = training.load_state_with_optimizer(path)
+        return fut.result() if hasattr(fut, "result") else fut
+    except Exception as e:
+        raise _wrap(e) from e

--- a/clawloop/weight_backends/tinker.py
+++ b/clawloop/weight_backends/tinker.py
@@ -1,0 +1,396 @@
+"""Tinker weights backend configuration and backend class.
+
+Holds the non-secret configuration for the Tinker weight backend. The
+``TINKER_API_KEY`` is read from the environment at backend construction time
+and is intentionally never stored on this dataclass — keeping secrets out of
+serialized configs, logs, and archive records.
+
+Field choices follow the v5.1 SDK preflight: Tinker 0.18.1 has no ``alpha``
+LoRA kwarg, ``AdamParams`` exposes only ``learning_rate, beta1, beta2, eps``
+(no ``weight_decay``), and ``save_weights_and_get_sampling_client`` does not
+accept a ``ttl_seconds`` argument. See the design doc v5.1 SDK overrides.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from tinker import types as _tinker_types
+from tinker_cookbook.model_info import get_recommended_renderer_name
+from tinker_cookbook.renderers import get_renderer
+
+from clawloop.config import load_env
+from clawloop.core.types import (
+    Datum,
+    FBResult,
+    Future,
+    LoadResult,
+    OptimResult,
+    SampleContext,
+    SampleResult,
+    SaveResult,
+)
+from clawloop.weight_backends import _tinker_sdk
+from clawloop.weight_backends._tinker_exporter import episodes_to_tinker_datums
+from clawloop.weight_backends._tinker_sdk import TinkerBackendError
+from clawloop.weight_backends.base import BackendError
+
+
+LossFn = Literal["importance_sampling", "cross_entropy", "ppo", "cispo", "dro"]
+
+
+@dataclass
+class TinkerWeightsConfig:
+    """Non-secret configuration. TINKER_API_KEY is read from env, never stored."""
+
+    base_model: str
+    lora_rank: int = 8
+    seed: int = 42
+    train_attn: bool = True
+    train_mlp: bool = True
+    train_unembed: bool = False
+    renderer_name: str | None = None
+    loss_fn: LossFn = "importance_sampling"
+    loss_fn_config: dict[str, Any] = field(default_factory=dict)
+    # Users can pass a partial dict (e.g. just ``learning_rate``). We merge
+    # with defaults at construction time in ``__post_init__`` so a partial
+    # override doesn't drop required AdamParams kwargs.
+    adam_params: dict[str, Any] = field(default_factory=dict)
+    # NOTE: Tinker 0.18.1 AdamParams has NO weight_decay field — do not include.
+    # TTL applied to durable training.save_state checkpoints written each iter.
+    # 1 hour by default; set None to retain (subject to account quotas).
+    ttl_seconds_intermediate: int | None = 3600
+
+    # Defaults that must appear on every AdamParams call; a partial user
+    # override is merged over these in ``__post_init__``.
+    _ADAM_DEFAULTS: "dict[str, Any]" = field(
+        default_factory=lambda: {
+            "learning_rate": 1e-5,
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "eps": 1e-8,
+        },
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        # Merge partial adam_params over defaults so users can write
+        # ``adam_params={"learning_rate": 5e-6}`` without dropping the rest.
+        merged = {**self._ADAM_DEFAULTS, **self.adam_params}
+        # Validate: every required kwarg present after merge.
+        required = {"learning_rate", "beta1", "beta2", "eps"}
+        missing = required - set(merged)
+        if missing:
+            raise ValueError(
+                f"adam_params missing required keys after merge: {sorted(missing)}"
+            )
+        self.adam_params = merged
+
+
+# ---------------------------------------------------------------------------
+# TinkerWeightsBackend (Task 8: __init__ + current_sampling_client)
+# ---------------------------------------------------------------------------
+
+
+class TinkerWeightsBackend:
+    """Tinker weight backend.
+
+    Task 8 covers only the constructor and the accessor methods. The
+    Layer-protocol methods (forward_backward, optim_step, save_state,
+    load_state, sample, to_dict, clear_pending_state) arrive in Task 9.
+
+    The base-model SamplingClient is created up-front so iter-0 rollouts
+    have a valid client BEFORE any save_state has been called. After the
+    first ``save_state``, ``current_sampling_client()`` will return the
+    adapter-bound client instead.
+    """
+
+    def __init__(self, config: TinkerWeightsConfig) -> None:
+        # 1. Load .env so TINKER_API_KEY can live in clawloop/.env.
+        load_env()
+
+        # 2. Fail fast if TINKER_API_KEY is still not in env.
+        if "TINKER_API_KEY" not in os.environ:
+            raise TinkerBackendError(
+                BackendError(
+                    code="missing_api_key",
+                    message=(
+                        "TINKER_API_KEY env var must be set (put it in "
+                        "clawloop/.env or export it) before constructing "
+                        "TinkerWeightsBackend."
+                    ),
+                    recoverable=False,
+                )
+            )
+
+        self._config = config
+        self._service = _tinker_sdk.make_service_client()
+
+        # 3. Training client (LoRA).
+        self._training = _tinker_sdk.create_training(
+            self._service,
+            base_model=config.base_model,
+            rank=config.lora_rank,
+            seed=config.seed,
+            train_attn=config.train_attn,
+            train_mlp=config.train_mlp,
+            train_unembed=config.train_unembed,
+        )
+
+        # 4. Tokenizer = single source of truth from the training client.
+        # We do NOT use HF AutoTokenizer anywhere.
+        self._tokenizer = self._training.get_tokenizer()
+
+        # 5. Renderer via tinker_cookbook — auto-select per model unless
+        # the user pinned one explicitly.
+        renderer_name = (
+            config.renderer_name
+            or get_recommended_renderer_name(config.base_model)
+        )
+        self._renderer = get_renderer(renderer_name, self._tokenizer)
+
+        # 6. Base-model SamplingClient — so iter 0 rollouts have a valid
+        # client BEFORE any save_state has been called.
+        self._sampling = _tinker_sdk.create_sampling(
+            self._service, base_model=config.base_model,
+        )
+        self._adapter_paths: list[str] = []
+        # Durable tinker:// paths from training.save_state — enumerable via
+        # RestClient.list_checkpoints. Populated alongside adapter_paths by
+        # save_state() below.
+        self._durable_paths: list[str] = []
+        self._rest = _tinker_sdk.make_rest_client(self._service)
+        self._model_id = _tinker_sdk.get_model_id(self._training)
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def model_id(self) -> str:
+        """Training-run identifier (used for RestClient.list_checkpoints)."""
+        return self._model_id
+
+    def list_tinker_checkpoints(self) -> list[dict[str, Any]]:
+        """Enumerate this run's durable checkpoints.
+
+        Ephemeral save_weights_and_get_sampling_client checkpoints are NOT
+        included — those are not listed by the Tinker REST API. Only the
+        ``save_state``-produced checkpoints we wrote explicitly show up.
+        """
+        return _tinker_sdk.list_checkpoints(self._rest, self._model_id)
+
+    def current_sampling_client(self) -> Any:
+        """Latest :class:`SamplingClient`.
+
+        Base-model client at iter 0; adapter-bound after the first
+        successful ``save_state`` (added in Task 9).
+        """
+        return self._sampling
+
+    @property
+    def renderer(self) -> Any:
+        return self._renderer
+
+    @property
+    def tokenizer(self) -> Any:
+        return self._tokenizer
+
+    @property
+    def config(self) -> TinkerWeightsConfig:
+        return self._config
+
+    # ------------------------------------------------------------------
+    # Layer protocol — forward_backward / optim_step
+    # ------------------------------------------------------------------
+
+    def forward_backward(self, data: Datum) -> Future[FBResult]:
+        """Run one fwd/bwd + optim_step on *data.episodes*.
+
+        Pipelining: we submit ``forward_backward`` and ``optim_step``
+        back-to-back BEFORE awaiting either. The Tinker SDK guarantees
+        ordering by submission, so the optimizer will see this step's
+        gradients. Awaiting both before returning keeps the public verb
+        simple — ``optim_step`` is a no-op so callers can still use the
+        two-phase Layer contract.
+        """
+        try:
+            tinker_datums = episodes_to_tinker_datums(
+                data.episodes, loss_fn=self._config.loss_fn
+            )
+            if not tinker_datums:
+                return Future.immediate(
+                    FBResult(
+                        status="ok",
+                        metrics={"n_datums": 0, "dropped": True},
+                    )
+                )
+
+            fb_future = _tinker_sdk.forward_backward(
+                self._training,
+                tinker_datums,
+                loss_fn=self._config.loss_fn,
+                loss_fn_config=self._config.loss_fn_config,
+            )
+            adam_params = _tinker_types.AdamParams(**self._config.adam_params)
+            opt_future = _tinker_sdk.optim_step(self._training, adam_params)
+
+            # Await both — order: fb first to surface fb errors first.
+            fb_out = (
+                fb_future.result() if hasattr(fb_future, "result") else fb_future
+            )
+            opt_out = (
+                opt_future.result()
+                if hasattr(opt_future, "result")
+                else opt_future
+            )
+
+            # Extract JSON-safe scalar metrics. The SDK's ForwardBackwardOutput
+            # / OptimStepResponse pack their stats in a `.metrics: dict[str, Any]`;
+            # reach into that rather than serializing the whole pydantic object.
+            fb_metrics = getattr(fb_out, "metrics", {}) or {}
+            opt_metrics = getattr(opt_out, "metrics", {}) or {}
+
+            metrics: dict[str, Any] = {
+                "n_datums": len(tinker_datums),
+                **{f"fb.{k}": v for k, v in fb_metrics.items()},
+                **{f"optim.{k}": v for k, v in opt_metrics.items()},
+            }
+            return Future.immediate(FBResult(status="ok", metrics=metrics))
+        except TinkerBackendError as e:
+            return Future.immediate(
+                FBResult(
+                    status="error",
+                    metrics={
+                        "error": {
+                            "code": e.code,
+                            "message": e.message,
+                            "recoverable": e.recoverable,
+                        }
+                    },
+                )
+            )
+
+    def optim_step(self) -> Future[OptimResult]:
+        """No-op — the optimizer step was already submitted+awaited inside
+        :meth:`forward_backward`. Returns a successful result so the
+        two-phase Layer contract is still satisfied for callers."""
+        return Future.immediate(
+            OptimResult(status="ok", updates_applied=1, metrics={})
+        )
+
+    # ------------------------------------------------------------------
+    # Layer protocol — sample
+    # ------------------------------------------------------------------
+
+    def sample(self, ctx: SampleContext) -> Future[SampleResult]:  # noqa: ARG002
+        """Return the latest adapter path identifier (or base model name).
+
+        The SamplingClient itself is accessed via
+        :meth:`current_sampling_client`; this method's return value is a
+        lightweight string identifier suitable for logging and state
+        hashing.
+        """
+        if self._adapter_paths:
+            output = self._adapter_paths[-1]
+        else:
+            output = self._config.base_model
+        return Future.immediate(SampleResult(output=output, metadata={}))
+
+    # ------------------------------------------------------------------
+    # Layer protocol — save_state / load_state
+    # ------------------------------------------------------------------
+
+    def save_state(self, name: str) -> Future[SaveResult]:
+        """Persist a checkpoint twice: ephemeral (→ fresh SamplingClient) +
+        durable (→ enumerable ``tinker://`` path).
+
+        Why both:
+        - ``save_weights_and_get_sampling_client`` gives us the client the
+          next iter's rollouts need, but is ephemeral and invisible to
+          ``list_checkpoints``.
+        - ``training.save_state(name)`` writes a durable, listable training
+          checkpoint we can resume from with ``load_state_with_optimizer``.
+        """
+        try:
+            new_sampling = _tinker_sdk.save_weights_and_get_sampling_client(
+                self._training, name
+            )
+            self._sampling = new_sampling
+            self._adapter_paths.append(name)
+            # Best-effort durable save. Failure here must not abort training —
+            # catch locally and surface via SaveResult.status with a hint.
+            try:
+                path = _tinker_sdk.save_state_durable(
+                    self._training, name,
+                    ttl_seconds=self._config.ttl_seconds_intermediate,
+                )
+                if path:
+                    self._durable_paths.append(path)
+            except TinkerBackendError as e:
+                return Future.immediate(
+                    SaveResult(name=name, status=f"ok_ephemeral_only: {e.code}")
+                )
+            return Future.immediate(SaveResult(name=name, status="ok"))
+        except TinkerBackendError as e:
+            return Future.immediate(
+                SaveResult(name=name, status=f"error: {e.code}")
+            )
+
+    def load_state(self, state: dict[str, Any]) -> Future[LoadResult]:
+        """Restore weights + optimizer from the last durable checkpoint.
+
+        Prefers ``durable_paths`` (real ``tinker://`` URIs) over
+        ``adapter_paths`` (ephemeral names). If neither is usable, no-op and
+        keep the base-model sampling client from __init__.
+        """
+        if not state:
+            return Future.immediate(LoadResult(status="ok"))
+        durable = state.get("durable_paths") or []
+        adapter = state.get("adapter_paths") or []
+        # Pick the real path if we have one; ephemeral names aren't reloadable.
+        last_path = durable[-1] if durable else (adapter[-1] if adapter else None)
+        if not last_path or not str(last_path).startswith("tinker://"):
+            return Future.immediate(LoadResult(status="ok"))
+        try:
+            _tinker_sdk.load_state_with_optimizer(self._training, last_path)
+            self._sampling = _tinker_sdk.create_sampling(
+                self._service, model_path=last_path
+            )
+            self._adapter_paths = list(adapter)
+            self._durable_paths = list(durable)
+            return Future.immediate(LoadResult(status="ok"))
+        except TinkerBackendError as e:
+            return Future.immediate(LoadResult(status=f"error: {e.code}"))
+
+    # ------------------------------------------------------------------
+    # Layer protocol — clear_pending_state / to_dict
+    # ------------------------------------------------------------------
+
+    def clear_pending_state(self) -> None:
+        """No-op — Tinker manages its own pending-gradient buffers."""
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a non-secret view of this backend.
+
+        Excludes the API key (which is read from env, not stored on the
+        config) and any other credential-like fields.
+        """
+        cfg = self._config
+        return {
+            "base_model": cfg.base_model,
+            "lora_rank": cfg.lora_rank,
+            "seed": cfg.seed,
+            "train_attn": cfg.train_attn,
+            "train_mlp": cfg.train_mlp,
+            "train_unembed": cfg.train_unembed,
+            "loss_fn": cfg.loss_fn,
+            "loss_fn_config": dict(cfg.loss_fn_config),
+            "adam_params": dict(cfg.adam_params),
+            "adapter_paths": list(self._adapter_paths),
+            "durable_paths": list(self._durable_paths),
+            "model_id": self._model_id,
+        }

--- a/examples/2048_tinker_pilot.yaml
+++ b/examples/2048_tinker_pilot.yaml
@@ -1,0 +1,36 @@
+mode: weight
+env_type: openspiel
+weight_backend: tinker
+
+openspiel:
+  game_name: "2048"
+  seeds: [0, 1, 2, 3, 4, 5, 6, 7]
+  episodes_per_seed: 4
+  prompt_style: canonical
+  rethink_k: 3
+  max_turns: 200
+  temperature: 1.0
+  top_p: 0.95
+  max_tokens: 128
+
+tinker:
+  base_model: Qwen/Qwen3-8B
+  lora_rank: 8
+  seed: 42
+  train_attn: true
+  train_mlp: true
+  train_unembed: false
+  loss_fn: importance_sampling
+  adam_params:
+    learning_rate: 1.0e-5
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1.0e-8
+
+n_iterations: 100
+system_prompt: |
+  You are playing 2048. Slide the tiles in one of four directions to combine
+  equal numbers and reach the 2048 tile. Each move shifts all tiles; equal
+  adjacent tiles merge into their sum. Always respond with `Final Answer: <move>`
+  where <move> is one of the listed legal moves.
+benches: ["2048"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,145 +1,111 @@
-# ClawLoop Examples
+# Tinker weight-tuning with ClawLoop — examples
 
-## Start Here
+A worked example of doing **reinforcement learning against a LoRA adapter
+trained on Thinking Machines Lab's managed [Tinker](https://thinkingmachines.ai)
+service**, using ClawLoop as the orchestration layer and
+[OpenSpiel](https://github.com/google-deepmind/open_spiel) as a reference
+environment.
 
-**Zero setup, 10 seconds:**
-```bash
-uv run clawloop demo math --dry-run
-```
+> **Use Tinker with a different env.** The pieces below are env-agnostic;
+> OpenSpiel is just the first adapter wired. See
+> [Using Tinker with another env](#using-tinker-with-another-env) at the
+> bottom for the Harbor-and-beyond story.
 
-**See the playbook learning internals:**
-```bash
-uv run python examples/playbook_demo.py --dry-run
-```
+## Start here
 
-Both run with mock LLMs — no API keys, no network, finishes instantly.
-
-## Choose Your Path
-
-### Harness demo: Python learning loop
-
-Use `ClawLoopAgent` with any litellm-supported LLM:
+The 100-line inline example, [`tinker_weight_demo.py`](tinker_weight_demo.py),
+builds a `TrainConfig` from Python, runs one Blackjack training iter against
+Tinker, and prints the durable Tinker checkpoint path it just wrote:
 
 ```bash
-# With Anthropic
-ANTHROPIC_API_KEY=... uv run python examples/demo_math.py
-
-# With OpenAI (weak task model, stronger critic)
-CLAWLOOP_TASK_MODEL=openai/gpt-4o-mini \
-CLAWLOOP_REFLECTOR_MODEL=openai/gpt-5.4-nano \
-    uv run python examples/demo_math.py
-
-# With Gemini (weak task model, stronger critic)
-CLAWLOOP_TASK_MODEL=gemini/gemini-2.0-flash-lite \
-CLAWLOOP_REFLECTOR_MODEL=gemini/gemini-2.5-flash-lite \
-    uv run python examples/demo_math.py
+# Put your TINKER_API_KEY in clawloop/.env (gitignored; see .env.example).
+uv sync --extra games
+uv run python examples/tinker_weight_demo.py
 ```
 
-For deeper control, see [`playbook_demo.py`](playbook_demo.py) — walks through
-the two-phase protocol (forward_backward → optim_step), playbook scoring,
-structured skill entries, and tag-based retrieval step by step.
+Reads cleanly top-to-bottom. Every place you'd change to adapt the demo to
+another env or another model is flagged with `[ADAPT]` comments.
 
-### Workflow integration: n8n webhooks
+## YAML recipes (longer runs)
 
-ClawLoop integrates with n8n via webhooks — no Python code in your workflow.
-An n8n workflow sends tickets to the LLM, posts traces to clawloop-server,
-and the server learns in the background.
+For multi-iter runs + cross-run comparison, use YAML + `scripts/run_pilot.py`:
 
-See [`n8n/README.md`](n8n/README.md) for setup, the importable workflow, and
-a demo script that shows a customer support agent improving across rounds.
-Set `CLAWLOOP_BASE_URL` in n8n if your Docker host cannot reach
-`host.docker.internal`.
-
-### Harness benchmarks: config-driven runner
-
-Use the unified `train_runner.py` with JSON configs. Same runner, different
-environments:
+| File | What it does |
+|---|---|
+| [`blackjack_tinker_pilot.yaml`](blackjack_tinker_pilot.yaml) | Single-game Blackjack on Qwen3-8B. |
+| [`blackjack_plus_2048_tinker_pilot.yaml`](blackjack_plus_2048_tinker_pilot.yaml) | **Multi-task RL in one LoRA** — Blackjack + 2048 episodes interleave into the same `forward_backward` batch; GRPO baselines stay per-scenario. |
 
 ```bash
-uv run python examples/train_runner.py examples/configs/math_harness.json        # math, prompt optimization
-uv run python examples/train_runner.py examples/configs/entropic_harness.json    # CRMArena A2A, prompt optimization
-uv run python examples/train_runner.py examples/configs/harbor_harness.json      # Harbor BFCL, prompt optimization
+uv run python scripts/run_pilot.py examples/blackjack_plus_2048_tinker_pilot.yaml \
+    --n-iterations 3 --output-dir pilot_runs/mixed_3iter
+
+# Live reward curves:
+uv run python -m http.server 8770 --bind 127.0.0.1
+# then http://localhost:8770/clawloop/static/learning_viewer.html?exp=/pilot_runs/mixed_3iter/experiment.jsonl
 ```
 
-Switch to weight training by changing `mode`:
+Add `--wandb-project NAME` to any run — metrics mirror through
+`tinker_cookbook.utils.ml_log.setup_logging` (Neptune on the same switch
+via `NEPTUNE_API_TOKEN`). No integration = Rich console tables + `experiment.jsonl` on disk.
 
-```bash
-uv run python examples/train_runner.py examples/configs/math_weight.json         # math, SkyRL on GPU
-uv run python examples/train_runner.py examples/configs/entropic_weight.json     # CRMArena, weight training
-uv run python examples/train_runner.py examples/configs/harbor_weight.json       # Harbor, weight training
-```
+## What each iteration does
 
-All configs follow the same `TrainConfig` schema. See [`configs/`](configs/)
-for the full set.
+1. Refresh `agent_state.sampling_client` from `backend.current_sampling_client()`.
+2. Fan out N episode rollouts via `asyncio.gather` over `OpenSpielGameAdapter.run_episodes_batch`. Tinker's `SamplingClient.sample` returns a `ConcurrentFuture`; we wrap it with `asyncio.wrap_future` so asyncio can actually interleave them (without the wrap, `.result()` serializes everything — we measured ~7–8× speedup from the fix).
+3. Each episode captures `prompt_tokens`, `sampled_tokens`, `sampling_logprobs` on `StepMeta.info` at sampling time. No tokenizer round-trip later.
+4. `episodes_to_tinker_datums` applies GRPO (group-mean subtraction per `task_id = f"{game}_seed_{seed}"`), drops zero-variance groups, emits one `tinker.types.Datum` per LLM turn with prompt positions zero-padded.
+5. `forward_backward` and `optim_step` submitted back-to-back as futures (both land in the same Tinker "clock cycle"), then awaited together.
+6. `save_state(f"iter_{i}")` writes a durable, enumerable checkpoint (`tinker://...`); `save_weights_and_get_sampling_client` returns the fresh `SamplingClient` the next iter will use for rollouts. The durable path is listable via `RestClient.list_checkpoints` and reloadable via `load_state_with_optimizer`.
 
-### Proxy harness: zero-code-change OpenClaw
+## The three files worth lifting
 
-The OpenClaw proxy sits transparently between any OpenAI-compatible agent
-and its LLM. It captures traces, learns from them, and injects playbook
-skills — without touching agent code:
+If you already have an RL loop and just want the Tinker bits:
 
-```bash
-cd examples/openclaw_runner && npm install && cd ../..
+- [`clawloop/weight_backends/_tinker_sdk.py`](../clawloop/weight_backends/_tinker_sdk.py) — thin typed adapter over the `tinker` SDK. One file you own; SDK drift lives in one place.
+- [`clawloop/weight_backends/_tinker_exporter.py`](../clawloop/weight_backends/_tinker_exporter.py) — `list[Episode] → list[tinker.Datum]` with episode-level GRPO baselines, strict token/logprob alignment, zero-variance filtering.
+- [`clawloop/weight_backends/tinker.py`](../clawloop/weight_backends/tinker.py) — `TinkerWeightsBackend` plugging into ClawLoop's `ClawLoopBackend` protocol. Dual save (ephemeral SamplingClient + durable `tinker://` path) every iter.
 
-UPSTREAM_URL=https://api.openai.com/v1 UPSTREAM_KEY=$OPENAI_API_KEY \
-    uv run python examples/openclaw_demo.py
-```
+## Using Tinker with another env
 
-Requires Node.js and an OpenAI-compatible Chat Completions endpoint.
-See [`openclaw_demo.py`](openclaw_demo.py) for the full annotated example.
+The only contract the exporter imposes on your env is that each rollout's
+`Episode` carries, for every LLM turn, a `StepMeta.info` dict with:
 
-### Remote OpenClaw: SSH-connected proxy harness
+- `prompt_tokens: list[int]` — exact tokens the SamplingClient saw.
+- `sampled_tokens: list[int]` — exact tokens it emitted.
+- `sampling_logprobs: list[float]` — per-token logprobs, aligned 1:1.
 
-Connect ClawLoop to your **remote** OpenClaw via SSH — no changes to your
-OpenClaw config, nothing installed permanently:
+`OpenSpielTaskEnvironment.run_episode` captures all three right at the
+sampling call site — see `_sample_one_llm_attempt` in
+`clawloop/environments/openspiel.py` for the pattern. Any env that *owns
+its sampling loop* can do the same.
 
-```bash
-# With Google Gemini:
-UPSTREAM_KEY=your-key uv run python examples/openclaw_demo_remote.py \
-    --host YOUR_HOST \
-    --upstream-url "https://generativelanguage.googleapis.com/v1beta/openai" \
-    --model gemini-2.5-flash-lite
+### Would Harbor work?
 
-# With a local model (Ollama on the same server):
-uv run python examples/openclaw_demo_remote.py \
-    --host YOUR_HOST \
-    --local-model localhost:11434 \
-    --model qwen3.5:0.8b
-```
+**Conceptually yes, ~50–100 LoC of wiring away.** Harbor's built-in agents
+(`claude-code`, `openhands`, `aider`, Terminus 2, …) sample via LiteLLM,
+which doesn't surface Tinker-compatible token IDs. Two ways to close the
+gap:
 
-Runs 10 benchmark tasks, learns strategies, re-runs with playbook injection,
-and prints a before/after comparison. Works with any Docker host with SSH
-access — Hetzner VPS, Mac Mini, DGX Spark, etc.
+1. **Ship a `TinkerAgent` in Harbor** that drives Tinker's `SamplingClient`
+   directly and writes the three `StepMeta.info` fields into the trial
+   trajectory. There's already a stub at
+   `benchmarks/harbor/src/harbor/llms/tinker.py` that could host this.
+2. **Write a `HarborTinkerAdapter` on the ClawLoop side** that wraps
+   `HarborTaskEnvironment`, intercepts the agent call, and captures the
+   fields during the trial run.
 
-See [`openclaw_demo_remote.py`](openclaw_demo_remote.py) for full docs,
-prerequisites, and all provider options.
+Either is a clean extension — the abstraction layers don't block it.
+Not wired today; filed as a follow-up so whoever ships it finds the
+design notes in one place.
 
-### Weight training: SkyRL/Tinker recipes
+## Scaling out
 
-The [recipes/](recipes/) directory contains SkyRL/Tinker-compatible scripts
-for GRPO, PPO, and full fine-tuning:
+- Swap `Qwen/Qwen3-8B` for any model in Tinker's catalog via `tinker.base_model` in the YAML (or the inline config). Run `scripts/tinker_preflight.py` against your account to see the live list.
+- Drop in new OpenSpiel games by appending to the `games:` list — GRPO groups stay per-scenario, reward scales don't cross-contaminate.
+- Bring your own env by implementing the `AdapterLike` Protocol in `clawloop/core/loop.py` and populating the `StepMeta.info` fields above. Backend, exporter, and logger are all game-agnostic.
 
-- **Arithmetic RL** — `recipes/arithmetic.py` (mirrors Tinker cookbook)
-- **Harbor BFCL** — `recipes/harbor_bfcl.py` (function calling in Docker)
-- **A2A CRMArena** — `recipes/a2a_crmarena.py` (multi-agent CRM tasks)
-- **Guess the Number** — `recipes/guess_number.py` (multi-turn RL)
+## Known limits (v1)
 
-See [`recipes/README.md`](recipes/README.md) for setup and details.
-
-## Mode Reference
-
-| `mode` | What trains | Infrastructure |
-|--------|------------|----------------|
-| `harness_learning` | System prompt via reflector | LLM API (no GPU) |
-| `weight` | Model weights via RL / fine-tuning | SkyRL/Tinker (vLLM + FSDP2 + Ray) on GPU |
-
-## Tested End-to-End
-
-| Env | harness_learning | weight |
-|-----|:---:|:---:|
-| Math | Gemini | Gemini + SkyRL |
-| Harbor BFCL | Gemini + Docker | Oracle + Docker + SkyRL |
-| Entropic A2A | Gemini | Gemini + SkyRL |
-| OpenClaw Proxy | OpenAI | -- |
-| OpenClaw Remote | Gemini, Ollama (qwen3, qwen3.5) | -- |
-| n8n Integration | any provider | -- |
+- Self-play for adversarial / hidden-info games is not wired — multi-player OpenSpiel games use a random opponent.
+- OpenSpiel's canonical action strings don't always match how an LLM writes moves (chess SAN, hanabi hint codes). `_parse_move_fallback` handles common cases; per-game parsers are a clean follow-up.
+- 2048's terminal reward only fires at the 2048 tile — rare at 30–50 turns. Intermediate reward shaping (score-delta, max-tile) is on the roadmap.

--- a/examples/blackjack_plus_2048_tinker_pilot.yaml
+++ b/examples/blackjack_plus_2048_tinker_pilot.yaml
@@ -1,0 +1,47 @@
+mode: weight
+env_type: openspiel
+weight_backend: tinker
+
+openspiel:
+  # Mixed-game training: both games land in the SAME forward_backward batch
+  # so ONE LoRA learns both. GRPO groups stay per-(game, seed) so each scenario
+  # has its own baseline and reward ranges don't cross-contaminate.
+  games:
+    - game_name: blackjack
+      seeds: [0, 1, 2, 3]
+      episodes_per_seed: 4
+      max_turns: 10
+    - game_name: "2048"
+      seeds: [0, 1, 2, 3]
+      episodes_per_seed: 4
+      # 2048 episodes can run 1000+ moves; 50 is a safe smoke cap. Can raise
+      # later once we know context-window / cost trade-offs empirically.
+      max_turns: 50
+
+  # Shared sampling knobs inherited by every game unless the per-game spec
+  # overrides them.
+  prompt_style: canonical
+  rethink_k: 3
+  temperature: 1.0
+  top_p: 0.95
+  max_tokens: 128
+
+tinker:
+  base_model: Qwen/Qwen3-8B
+  lora_rank: 8
+  seed: 42
+  train_attn: true
+  train_mlp: true
+  train_unembed: false
+  loss_fn: importance_sampling
+  adam_params:
+    learning_rate: 1.0e-5
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1.0e-8
+
+n_iterations: 3   # smoke default — bump on the CLI via --n-iterations
+system_prompt: |
+  You are playing a board / card game. Read the state, pick from the listed
+  legal moves, and respond with exactly `Final Answer: <move>`.
+benches: [blackjack, "2048"]

--- a/examples/blackjack_tinker_pilot.yaml
+++ b/examples/blackjack_tinker_pilot.yaml
@@ -1,0 +1,34 @@
+mode: weight
+env_type: openspiel
+weight_backend: tinker
+
+openspiel:
+  game_name: blackjack
+  seeds: [0, 1, 2, 3, 4, 5, 6, 7]
+  episodes_per_seed: 4
+  prompt_style: canonical
+  rethink_k: 3
+  max_turns: 10
+  temperature: 1.0
+  top_p: 0.95
+  max_tokens: 128
+
+tinker:
+  base_model: Qwen/Qwen3-8B
+  lora_rank: 8
+  seed: 42
+  train_attn: true
+  train_mlp: true
+  train_unembed: false
+  loss_fn: importance_sampling
+  adam_params:
+    learning_rate: 1.0e-5
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1.0e-8
+
+n_iterations: 100
+system_prompt: |
+  You are playing Blackjack. Always respond with `Final Answer: <move>` where
+  <move> is one of the listed legal moves.
+benches: [blackjack]

--- a/examples/tinker_weight_demo.py
+++ b/examples/tinker_weight_demo.py
@@ -1,0 +1,148 @@
+"""Tinker weight-tuning demo — 1 iter of RL against an OpenSpiel game.
+
+**What this demonstrates**
+
+A minimal, runnable example of how ClawLoop wraps Thinking Machines Lab's
+managed [Tinker](https://thinkingmachines.ai) LoRA-training service for
+reinforcement learning. Runs Qwen3-8B for ONE iter (8 Blackjack episodes)
+against Tinker, producing per-iter metrics + a durable adapter checkpoint.
+
+**What it's not**
+
+A benchmark. One iter is for plumbing validation. For real runs see
+``scripts/run_pilot.py`` + the YAMLs alongside this file.
+
+**Prerequisites**
+
+- ``TINKER_API_KEY`` in ``clawloop/.env`` (or as env var).
+- Install the games extra:    ``uv sync --extra games``
+
+**Run**
+
+    uv run python examples/tinker_weight_demo.py
+
+**What you'll see**
+
+- Rich console table per iter (``avg_reward``, ``loss:sum``, ``n_datums``).
+- ``pilot_runs/tinker_demo/experiment.jsonl`` with full trace.
+- A durable Tinker checkpoint at ``tinker://.../weights/iter_0`` enumerable
+  via ``backend.list_tinker_checkpoints()``.
+
+**Adapting this to another env**
+
+The pieces you'd change are marked with ``[ADAPT]`` comments. The short
+version: your env's ``Episode``s must carry ``prompt_tokens``,
+``sampled_tokens``, and ``sampling_logprobs`` in ``StepMeta.info`` — those
+are the alignment payload the exporter reads directly so it never has to
+re-tokenize anything.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+
+from clawloop.config import load_env
+from clawloop.train import TrainConfig, train
+
+
+def main() -> int:
+    # 1. Bring TINKER_API_KEY into the process env.  Works from clawloop/.env
+    #    (preferred — gitignored) or a process-level export.
+    load_env()
+
+    # 2. Define the training config.  This is the same shape you'd put in
+    #    a YAML and pass to `scripts/run_pilot.py`; we inline it here so
+    #    the moving parts are visible on one screen.
+    config = TrainConfig(
+        mode="weight",                 # [ADAPT] "weight" trains via a weights backend
+        env_type="openspiel",          # [ADAPT] swap for your env_type once registered
+        weight_backend="tinker",       # [ADAPT] stays "tinker" for Tinker-backed training
+
+        # [ADAPT] env-specific config — put anything your `_build_<env>` needs here.
+        # `episodes_per_iter` is derived automatically from `seeds × episodes_per_seed`
+        # by `effective_episodes_per_iter(config)` — here: 4 seeds * 2 = 8 episodes/iter.
+        openspiel={
+            "game_name": "blackjack",
+            "seeds": [0, 1, 2, 3],
+            "episodes_per_seed": 2,    # GRPO needs K >= 2 per scenario for variance
+            "prompt_style": "canonical",
+            "rethink_k": 3,
+            "max_turns": 10,
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "max_tokens": 128,
+        },
+
+        # Tinker LoRA training knobs.  `base_model` must be in
+        # `service.get_server_capabilities().supported_models`; run
+        # `scripts/tinker_preflight.py` to see the live list for your account.
+        tinker={
+            "base_model": "Qwen/Qwen3-8B",
+            "lora_rank": 8,
+            "seed": 42,
+            "train_attn": True,
+            "train_mlp": True,
+            "train_unembed": False,
+            "loss_fn": "importance_sampling",
+            "adam_params": {
+                "learning_rate": 1.0e-5,
+                "beta1": 0.9,
+                "beta2": 0.999,
+                "eps": 1.0e-8,
+            },
+        },
+
+        n_iterations=1,                # Smoke — one iter. Bump for real runs.
+        output_dir="pilot_runs/tinker_demo",
+
+        # Optional: mirror metrics to wandb.  Requires `WANDB_API_KEY` in
+        # env or .env.  Disabled by default so the demo runs without signup.
+        # wandb_project="clawloop-tinker-demo",
+    )
+
+    # 3. Run. This builds the ClawLoop layers, wires TinkerWeightsBackend,
+    #    fans out 8 Blackjack rollouts concurrently against Tinker's
+    #    SamplingClient (see `asyncio.gather` + `asyncio.wrap_future` in
+    #    `OpenSpielGameAdapter.run_episodes_batch`), aggregates per-task
+    #    GRPO advantages, calls `forward_backward` + `optim_step` as
+    #    pipelined futures, and finally writes a durable Tinker checkpoint
+    #    via `save_state` + `save_weights_and_get_sampling_client`.
+    agent_state, state_id = train(config)
+
+    # 4. Inspect what landed on Tinker's side.  The backend exposes
+    #    `list_tinker_checkpoints()` which calls RestClient.list_checkpoints
+    #    under the hood — this is how you'd enumerate, delete, or reload
+    #    saved LoRA adapters programmatically.
+    backend = getattr(agent_state.weights, "_backend", None)
+    if backend is not None and hasattr(backend, "list_tinker_checkpoints"):
+        checkpoints = backend.list_tinker_checkpoints()
+        print()
+        print(f"Tinker model_id: {backend.model_id}")
+        print(f"Durable checkpoints ({len(checkpoints)}):")
+        for ck in checkpoints:
+            print(
+                f"  {ck.get('checkpoint_type')}  "
+                f"{ck.get('tinker_path')}  "
+                f"({ck.get('size_bytes')} bytes, "
+                f"expires {ck.get('expires_at')})"
+            )
+
+    print()
+    print(f"Final state_id: {state_id.combined_hash[:12]}")
+    print(f"Logs + reward curves: {config.output_dir}/experiment.jsonl")
+    print()
+    print("Open the live viewer:")
+    print("  python -m http.server 8770 --bind 127.0.0.1")
+    print(
+        "  then http://localhost:8770/clawloop/static/learning_viewer.html"
+        f"?exp=/{config.output_dir}/experiment.jsonl"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "litellm>=1.0",
     "pydantic>=2.0",
+    "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -49,6 +50,16 @@ server = [
 taubench = [
     "tau2 @ git+https://github.com/sierra-research/tau2-bench.git@dev/tau3",
 ]
+games = [
+    "tinker>=0.18,<0.20",
+    "tinker-cookbook>=0.1.0",
+    "open_spiel>=1.5",
+    "numpy>=1.26",
+    "orjson>=3.9",  # transitive for tinker 0.18.x until Tinker declares it
+    # game_arena has no PyPI release; pinned to main SHA captured 2026-04-17.
+    "game_arena @ git+https://github.com/google-deepmind/game_arena@6ddcc7dac06321472f2f22fabdeceab97eebeb73",
+]
+
 [project.scripts]
 clawloop = "clawloop.cli:main"
 clawloop-server = "clawloop.server:main"

--- a/scripts/eval_openspiel.py
+++ b/scripts/eval_openspiel.py
@@ -1,0 +1,83 @@
+"""Eval a ClawLoop Tinker adapter on a disjoint OpenSpiel seed pool.
+
+Prints mean, stdev, sem for the returned rewards. Use before/after a training
+run to verify learning (the pool is disjoint from training seeds).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import statistics
+import sys
+
+from clawloop.config import load_env
+from clawloop.core.loop import AgentState
+from clawloop.environments.openspiel import (
+    OpenSpielTaskConfig, OpenSpielTaskEnvironment,
+)
+from clawloop.weight_backends.tinker import TinkerWeightsBackend, TinkerWeightsConfig
+
+
+def _parse_seed_range(spec: str) -> list[int]:
+    if ":" in spec:
+        lo, hi = spec.split(":")
+        return list(range(int(lo), int(hi)))
+    return [int(x) for x in spec.split(",")]
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-model", default="Qwen/Qwen3-8B")
+    parser.add_argument("--game", required=True,
+                        help="OpenSpiel game_name (blackjack, twenty_forty_eight, ...)")
+    parser.add_argument("--adapter-path", default="",
+                        help="tinker:// path, or empty to eval the base model.")
+    parser.add_argument("--seeds", default="1000:1064",
+                        help="seed range (lo:hi) or comma-separated list")
+    parser.add_argument("--max-turns", type=int, default=10)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--top-p", type=float, default=0.95)
+    args = parser.parse_args()
+
+    load_env()
+
+    backend = TinkerWeightsBackend(TinkerWeightsConfig(base_model=args.base_model))
+    if args.adapter_path:
+        backend.load_state({"adapter_paths": [args.adapter_path]}).result()
+
+    cfg = OpenSpielTaskConfig(
+        game_name=args.game, seeds=[0],
+        max_turns=args.max_turns, max_tokens=args.max_tokens,
+        temperature=args.temperature, top_p=args.top_p,
+    )
+    seeds = _parse_seed_range(args.seeds)
+
+    returns: list[float] = []
+    illegals = 0
+    for seed in seeds:
+        env = OpenSpielTaskEnvironment(cfg, seed=seed)
+        state = AgentState(
+            sampling_client=backend.current_sampling_client(),
+            renderer=backend.renderer,
+            tokenizer=backend.tokenizer,
+        )
+        episode = await env.run_episode(state)
+        returns.append(episode.summary.effective_reward())
+        if episode.summary.signals.get("illegal_parse") is not None:
+            sig = episode.summary.signals["illegal_parse"]
+            v = sig.value if hasattr(sig, "value") else sig
+            if v and v > 0:
+                illegals += 1
+
+    mean = statistics.mean(returns)
+    stdev = statistics.stdev(returns) if len(returns) > 1 else 0.0
+    sem = stdev / (len(returns) ** 0.5) if returns else 0.0
+    print(f"game={args.game} n={len(returns)} mean={mean:.4f} stdev={stdev:.4f} "
+          f"sem={sem:.4f} illegal_rate={illegals}/{len(returns)} = "
+          f"{illegals/max(len(returns),1):.2%}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/scripts/run_parallel_pilots.py
+++ b/scripts/run_parallel_pilots.py
@@ -1,0 +1,71 @@
+"""Run multiple ClawLoop pilots concurrently as subprocesses.
+
+Each pilot runs in its own process with its own output dir + log files.
+The runner waits for all processes to complete and returns non-zero if any
+failed. Real-time streaming to per-pilot log files; summary at end.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _parse_pilot_spec(spec: str) -> tuple[str, Path]:
+    if "=" not in spec:
+        raise ValueError(f"--pilot expects NAME=PATH, got: {spec}")
+    name, path = spec.split("=", 1)
+    return name, Path(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pilot", action="append", required=True,
+                        help="NAME=CONFIG_PATH; may be passed multiple times")
+    parser.add_argument("--n-iterations", type=int, required=True)
+    parser.add_argument("--base-output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    pilots = [_parse_pilot_spec(p) for p in args.pilot]
+    args.base_output_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_root = Path(__file__).resolve().parent.parent  # clawloop/
+    runner = repo_root / "scripts" / "run_pilot.py"
+
+    procs = []
+    for name, cfg_path in pilots:
+        out_dir = args.base_output_dir / name
+        out_dir.mkdir(parents=True, exist_ok=True)
+        log_path = out_dir / "pilot.log"
+        log_fh = log_path.open("w")
+        cmd = [
+            sys.executable, "-u", str(runner), str(cfg_path),
+            "--n-iterations", str(args.n_iterations),
+            "--output-dir", str(out_dir),
+        ]
+        print(f"[{name}] starting: {' '.join(cmd)} (log: {log_path})")
+        p = subprocess.Popen(cmd, stdout=log_fh, stderr=subprocess.STDOUT)
+        procs.append((name, p, log_fh, log_path))
+
+    # Wait for all.
+    start = time.time()
+    results = []
+    for name, p, log_fh, log_path in procs:
+        rc = p.wait()
+        log_fh.close()
+        elapsed = time.time() - start
+        results.append((name, rc, log_path))
+        status = "OK" if rc == 0 else f"FAIL (rc={rc})"
+        print(f"[{name}] {status} after {elapsed:.1f}s — log: {log_path}")
+
+    any_fail = any(rc != 0 for _, rc, _ in results)
+    print("\nSummary:")
+    for name, rc, log_path in results:
+        print(f"  {name}: rc={rc}  log={log_path}")
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_pilot.py
+++ b/scripts/run_pilot.py
@@ -1,0 +1,48 @@
+"""Run a ClawLoop training pilot from a YAML config.
+
+Generic — pass any config; --n-iterations overrides the YAML for smoke tests.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from clawloop.config import load_env
+from clawloop.train import TrainConfig, train
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", type=Path)
+    parser.add_argument("--n-iterations", type=int, default=None,
+                        help="override n_iterations (e.g. 1 for smoke test)")
+    parser.add_argument("--output-dir", type=Path, default=None,
+                        help="override output_dir for logs")
+    parser.add_argument("--wandb-project", default=None,
+                        help="if set, mirror metrics to this wandb project (requires WANDB_API_KEY)")
+    parser.add_argument("--wandb-name", default=None,
+                        help="optional wandb run name (defaults to output_dir basename)")
+    args = parser.parse_args()
+
+    load_env()  # pick up TINKER_API_KEY (and WANDB_API_KEY if present) from clawloop/.env
+
+    raw = yaml.safe_load(args.config.read_text())
+    if args.n_iterations is not None:
+        raw["n_iterations"] = args.n_iterations
+    if args.output_dir is not None:
+        raw["output_dir"] = str(args.output_dir)
+    if args.wandb_project is not None:
+        raw["wandb_project"] = args.wandb_project
+    if args.wandb_name is not None:
+        raw["wandb_name"] = args.wandb_name
+    cfg = TrainConfig.model_validate(raw)
+    result = train(cfg)
+    print("done", result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tinker_preflight.py
+++ b/scripts/tinker_preflight.py
@@ -1,0 +1,142 @@
+"""Tinker SDK preflight validation.
+
+Validates that the real Tinker SDK surface matches the assumptions made in
+the v5 design doc. Does not swallow exceptions — the whole point of this
+spike is to surface SDK drift loudly.
+
+Run:
+    python clawloop/scripts/tinker_preflight.py
+
+Requires `TINKER_API_KEY` (loaded from `clawloop/.env` via `load_env`).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+import tinker
+from tinker import types
+
+from clawloop.config import load_env
+
+
+def main() -> int:
+    load_env()
+
+    if "TINKER_API_KEY" not in os.environ:
+        raise SystemExit(
+            "TINKER_API_KEY is not set. Put it in clawloop/.env "
+            "(or export it) and rerun. load_env() did not find it."
+        )
+
+    # 2. ServiceClient
+    service = tinker.ServiceClient()
+    print("ok: ServiceClient()")
+
+    # 3. LoRA training client
+    training = service.create_lora_training_client(
+        base_model="Qwen/Qwen3-8B",
+        rank=8,
+        seed=42,
+        train_attn=True,
+        train_mlp=True,
+        train_unembed=False,
+    )
+    print("ok: create_lora_training_client(..., rank, seed, train_*)")
+
+    # 4. Tokenizer
+    tokenizer = training.get_tokenizer()
+    print(f"ok: training.get_tokenizer -> {type(tokenizer).__name__}")
+
+    # 5. Base-model sampling client
+    sampling = service.create_sampling_client(base_model="Qwen/Qwen3-8B")
+    assert hasattr(sampling, "sample"), "sampling client missing .sample()"
+    print("ok: create_sampling_client(base_model=...)")
+
+    # 6. Sample once (futures-based). sample() takes a ModelInput prompt
+    # + num_samples + SamplingParams (NOT prompt_tokens=list[int] kwargs).
+    prompt_text = "Hello"
+    prompt_ids = list(tokenizer.encode(prompt_text))
+    prompt_input = types.ModelInput(
+        chunks=[types.EncodedTextChunk(tokens=prompt_ids)]
+    )
+    sampling_params = types.SamplingParams(
+        max_tokens=8, temperature=1.0, top_p=0.95,
+    )
+    fut = sampling.sample(
+        prompt=prompt_input,
+        num_samples=1,
+        sampling_params=sampling_params,
+    )
+    resp = fut.result()
+    assert hasattr(resp, "sequences"), "SampleResponse missing .sequences"
+    assert len(resp.sequences) == 1, f"expected 1 sample, got {len(resp.sequences)}"
+    seq = resp.sequences[0]
+    assert hasattr(seq, "tokens"), "SampledSequence missing .tokens"
+    assert hasattr(seq, "logprobs"), "SampledSequence missing .logprobs"
+    assert seq.logprobs is not None and len(seq.tokens) == len(seq.logprobs), (
+        f"sampled_tokens/logprobs alignment broken: "
+        f"{len(seq.tokens)} tokens vs {len(seq.logprobs) if seq.logprobs else 'None'} logprobs"
+    )
+    print(f"ok: sample returns sequences[0].tokens+logprobs len {len(seq.tokens)} (stop={seq.stop_reason})")
+
+    # 7. Build minimal Datum using the sampled tokens.
+    sampled_tokens = list(seq.tokens)
+    sampled_logprobs = list(seq.logprobs)
+    tokens = prompt_ids + sampled_tokens
+    n_prompt = len(prompt_ids)
+    n_comp = len(sampled_tokens)
+    datum = types.Datum(
+        model_input=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=tokens)]),
+        loss_fn_inputs={
+            "target_tokens": np.array(
+                [0] * n_prompt + sampled_tokens, dtype=np.int64
+            ),
+            "logprobs": np.array(
+                [0.0] * n_prompt + sampled_logprobs, dtype=np.float32
+            ),
+            "advantages": np.array(
+                [0.0] * n_prompt + [1.0] * n_comp, dtype=np.float32
+            ),
+        },
+    )
+
+    # 8. Pipelined forward_backward + optim_step.
+    # optim_step takes a typed AdamParams object (not a dict).
+    fb_fut = training.forward_backward(
+        data=[datum],
+        loss_fn="importance_sampling",
+        loss_fn_config=None,
+    )
+    opt_fut = training.optim_step(
+        types.AdamParams(
+            learning_rate=1e-5, beta1=0.9, beta2=0.999, eps=1e-8,
+        )
+    )
+    fb_out = fb_fut.result()
+    opt_out = opt_fut.result()  # noqa: F841 -- force resolution
+    print("ok: forward_backward + optim_step pipelined")
+    fb_metrics = getattr(fb_out, "metrics", None) or {}
+    if isinstance(fb_metrics, dict):
+        first_keys = list(fb_metrics.keys())[:5]
+    else:
+        first_keys = []
+    print(f"    fb metrics keys: {first_keys}")
+
+    # 9. Atomic save + fresh sampling client.
+    # Real signature: save_weights_and_get_sampling_client(name, retry_config) -> SamplingClient.
+    # No ttl_seconds. Returns SamplingClient directly.
+    new_sampling = training.save_weights_and_get_sampling_client("preflight_iter_0")
+    assert hasattr(new_sampling, "sample"), (
+        "save_weights_and_get_sampling_client must return a SamplingClient"
+    )
+    print("ok: save_weights_and_get_sampling_client -> SamplingClient")
+
+    print("\nALL PREFLIGHT CHECKS PASSED.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,0 +1,60 @@
+"""Unit tests for clawloop.config.load_env."""
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _reload_module():
+    import clawloop.config as m
+    importlib.reload(m)
+    return m
+
+
+def test_load_env_is_idempotent(monkeypatch, tmp_path):
+    envfile = tmp_path / ".env"
+    envfile.write_text("CLAWLOOP_TEST_ONLY_KEY=hello\n")
+    monkeypatch.setenv("CLAWLOOP_ENV_FILE", str(envfile))
+    monkeypatch.delenv("CLAWLOOP_TEST_ONLY_KEY", raising=False)
+
+    m = _reload_module()
+    loaded_first = m.load_env()
+    loaded_second = m.load_env()
+    assert len(loaded_first) >= 1
+    assert loaded_second == []  # idempotent
+    assert os.environ["CLAWLOOP_TEST_ONLY_KEY"] == "hello"
+
+
+def test_load_env_override_path_is_honored(monkeypatch, tmp_path):
+    envfile = tmp_path / "custom.env"
+    envfile.write_text("CLAWLOOP_TEST_OVERRIDE=1\n")
+    monkeypatch.setenv("CLAWLOOP_ENV_FILE", str(envfile))
+    monkeypatch.delenv("CLAWLOOP_TEST_OVERRIDE", raising=False)
+
+    m = _reload_module()
+    m.load_env(force=True)
+    assert os.environ["CLAWLOOP_TEST_OVERRIDE"] == "1"
+
+
+def test_load_env_never_overrides_existing(monkeypatch, tmp_path):
+    envfile = tmp_path / ".env"
+    envfile.write_text("CLAWLOOP_TEST_KEEP=from_env_file\n")
+    monkeypatch.setenv("CLAWLOOP_ENV_FILE", str(envfile))
+    monkeypatch.setenv("CLAWLOOP_TEST_KEEP", "from_process")
+
+    m = _reload_module()
+    m.load_env(force=True)
+    # Existing var survives — .env never overrides process-level.
+    assert os.environ["CLAWLOOP_TEST_KEEP"] == "from_process"
+
+
+def test_load_env_missing_file_is_silent(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWLOOP_ENV_FILE", str(tmp_path / "nonexistent.env"))
+    m = _reload_module()
+    # Must not raise even if override path does not exist.
+    result = m.load_env(force=True)
+    # result may be empty, but crucially no exception.
+    assert isinstance(result, list)

--- a/tests/unit/core/test_loop.py
+++ b/tests/unit/core/test_loop.py
@@ -1,0 +1,165 @@
+"""Unit tests for clawloop.core.loop."""
+
+
+def test_agent_state_has_sampling_client_field_default_none():
+    from clawloop.core.loop import AgentState
+    state = AgentState()
+    assert hasattr(state, "sampling_client")
+    assert state.sampling_client is None
+
+
+def test_agent_state_has_renderer_and_tokenizer_fields_default_none():
+    from clawloop.core.loop import AgentState
+    state = AgentState()
+    assert hasattr(state, "renderer") and state.renderer is None
+    assert hasattr(state, "tokenizer") and state.tokenizer is None
+
+
+def test_learning_loop_refreshes_sampling_client_and_calls_save_state_per_iter():
+    """Each iteration: refresh agent_state.sampling_client from backend + save_state at end."""
+    from unittest.mock import MagicMock
+
+    from clawloop.core.episode import Episode, EpisodeSummary
+    from clawloop.core.loop import AgentState, learning_loop
+    from clawloop.core.reward import RewardSignal
+    from clawloop.core.types import FBResult, Future, OptimResult, SaveResult
+
+    # --- Build a fake backend that has current_sampling_client + save_state
+    sampling_clients = [MagicMock(name=f"sc_{i}") for i in range(3)]
+    saved: list[str] = []
+
+    def _current_sampling_client():
+        # Returns sc_0 before any save, sc_1 after first save, sc_2 after second.
+        return sampling_clients[len(saved)]
+
+    def _save_state(name):
+        saved.append(name)
+        fut = MagicMock()
+        fut.result.return_value = SaveResult(name=name, status="ok")
+        return fut
+
+    backend = MagicMock()
+    backend.current_sampling_client.side_effect = _current_sampling_client
+    backend.save_state.side_effect = _save_state
+    backend.renderer = MagicMock(name="renderer")
+    backend.tokenizer = MagicMock(name="tokenizer")
+
+    # --- Fake Weights wrapper so _backend lookup works
+    weights = MagicMock()
+    weights._backend = backend
+    weights.forward_backward = MagicMock(
+        return_value=Future.immediate(FBResult(status="ok", metrics={"n_datums": 1})),
+    )
+    weights.optim_step = MagicMock(
+        return_value=Future.immediate(OptimResult(status="ok", updates_applied=1, metrics={})),
+    )
+    weights.to_dict = MagicMock(return_value={})
+    weights.load_state = MagicMock(return_value=Future.immediate(object()))
+    weights.clear_pending_state = MagicMock()
+
+    # --- Fake adapter recording which sampling_client was in effect at rollout time
+    captured_clients: list = []
+
+    def _fake_run_episode(task_id, agent_state):
+        captured_clients.append(agent_state.sampling_client)
+        summary = EpisodeSummary(
+            signals={
+                "outcome": RewardSignal(name="outcome", value=0.0, confidence=1.0),
+            },
+        )
+        return Episode(
+            id="fake-id",
+            state_id="",
+            task_id=task_id,
+            bench="test",
+            messages=[],
+            step_boundaries=[],
+            steps=[],
+            summary=summary,
+        )
+
+    adapter = MagicMock()
+    adapter.run_episode.side_effect = _fake_run_episode
+    # Force the loop to use run_episode (not run_batch / run_episodes_batch).
+    if hasattr(adapter, "run_batch"):
+        del adapter.run_batch
+    if hasattr(adapter, "run_episodes_batch"):
+        del adapter.run_episodes_batch
+
+    # Seed state and run 2 iters.
+    agent_state = AgentState(weights=weights)
+    learning_loop(
+        adapter=adapter,
+        agent_state=agent_state,
+        tasks=["t1"],
+        n_episodes=1,
+        n_iterations=2,
+        active_layers=["weights"],
+    )
+
+    # Iter 0 rollouts saw sc_0; iter 1 rollouts saw sc_1 (after iter-0 save).
+    assert len(captured_clients) == 2
+    assert captured_clients[0] is sampling_clients[0]
+    assert captured_clients[1] is sampling_clients[1]
+    # save_state called with iter_0 and iter_1.
+    assert saved == ["iter_0", "iter_1"]
+
+
+def test_learning_loop_tolerates_backend_without_hooks():
+    """Existing SkyRL-style backend lacking current_sampling_client must still run."""
+    from unittest.mock import MagicMock
+
+    from clawloop.core.episode import Episode, EpisodeSummary
+    from clawloop.core.loop import AgentState, learning_loop
+    from clawloop.core.reward import RewardSignal
+    from clawloop.core.types import FBResult, Future, OptimResult
+
+    # Build a minimal backend WITHOUT current_sampling_client / save_state
+    # (pure spec so attribute access returns AttributeError for those).
+    backend = MagicMock(spec=["forward_backward", "optim_step"])
+    weights = MagicMock()
+    weights._backend = backend
+    weights.forward_backward = MagicMock(
+        return_value=Future.immediate(FBResult(status="ok", metrics={"n_datums": 1})),
+    )
+    weights.optim_step = MagicMock(
+        return_value=Future.immediate(OptimResult(status="ok", updates_applied=1, metrics={})),
+    )
+    weights.to_dict = MagicMock(return_value={})
+    weights.load_state = MagicMock(return_value=Future.immediate(object()))
+    weights.clear_pending_state = MagicMock()
+
+    def _fake_run_episode(task_id, agent_state):
+        summary = EpisodeSummary(
+            signals={
+                "outcome": RewardSignal(name="outcome", value=0.0, confidence=1.0),
+            },
+        )
+        return Episode(
+            id="fake-id",
+            state_id="",
+            task_id=task_id,
+            bench="test",
+            messages=[],
+            step_boundaries=[],
+            steps=[],
+            summary=summary,
+        )
+
+    adapter = MagicMock()
+    adapter.run_episode.side_effect = _fake_run_episode
+    if hasattr(adapter, "run_batch"):
+        del adapter.run_batch
+    if hasattr(adapter, "run_episodes_batch"):
+        del adapter.run_episodes_batch
+
+    agent_state = AgentState(weights=weights)
+    # Should not raise.
+    learning_loop(
+        adapter=adapter,
+        agent_state=agent_state,
+        tasks=["t1"],
+        n_episodes=1,
+        n_iterations=1,
+        active_layers=["weights"],
+    )

--- a/tests/unit/environments/test_openspiel.py
+++ b/tests/unit/environments/test_openspiel.py
@@ -1,0 +1,367 @@
+"""Unit tests for the OpenSpiel env skeleton.
+
+`run_episode` is implemented in Task 13 — not tested here.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# The OpenSpiel env has three optional runtime deps:
+#   - pyspiel (open_spiel): for `pyspiel.load_game()` in run_episode
+#   - pytest-asyncio: for @pytest.mark.asyncio support
+#   - tinker: for `_tinker_sdk.async_sample` inside run_episode
+# All three live in the `games` extra; CI without that extra skips.
+pytest.importorskip("pyspiel")
+pytest.importorskip("pytest_asyncio")
+pytest.importorskip("tinker")
+
+
+@pytest.mark.asyncio
+async def test_sample_one_llm_attempt_raises_on_none_logprobs():
+    """_sample_one_llm_attempt must hard-fail when the SamplingClient returns
+    None for .logprobs — silently falling back to 0.0 would give log(1)=prob 1.0
+    IS ratios for importance_sampling loss (mathematically bogus)."""
+    import concurrent.futures
+    from clawloop.environments import openspiel as osp
+
+    # Build a fake sampling_client.sample() that returns sequences[0].logprobs=None
+    fake_seq = MagicMock()
+    fake_seq.tokens = [10, 11, 12]
+    fake_seq.logprobs = None  # <-- the failure case
+    fake_response = MagicMock()
+    fake_response.sequences = [fake_seq]
+    fut = concurrent.futures.Future()
+    fut.set_result(fake_response)
+    sampling_client = MagicMock()
+    sampling_client.sample.return_value = fut
+
+    fake_tokenizer = MagicMock()
+    fake_renderer = MagicMock(spec=[])   # no build_generation_prompt
+    fake_tokenizer.apply_chat_template.return_value = [1, 2, 3]
+    fake_tokenizer.decode.return_value = "<text>"
+
+    fake_state = MagicMock()
+    fake_state.current_player.return_value = 0
+    fake_state.legal_actions.return_value = [0, 1]
+    fake_state.action_to_string.side_effect = lambda p, a: {0: "A", 1: "B"}[a]
+    fake_state.is_simultaneous_node.return_value = False
+
+    cfg = osp.OpenSpielTaskConfig(game_name="blackjack", seeds=[0])
+
+    with pytest.raises(RuntimeError, match="None for .logprobs"):
+        await osp._sample_one_llm_attempt(
+            sampling_client=sampling_client,
+            renderer=fake_renderer,
+            tokenizer=fake_tokenizer,
+            cfg=cfg,
+            turn_messages=[],
+            state=fake_state,
+            player=0,
+        )
+
+
+def test_run_episodes_batch_concurrent():
+    """run_episodes_batch gathers async episodes — episodes execute concurrently."""
+    import asyncio
+    from clawloop.environments.openspiel import (
+        OpenSpielGameAdapter, OpenSpielTaskConfig, OpenSpielTaskEnvironment,
+    )
+
+    # Stub envs whose async run_episode sleeps briefly + records start/end times.
+    timings: list[tuple[str, float, float]] = []
+    import time as _time
+
+    class _StubEnv:
+        def __init__(self, name):
+            self._name = name
+        async def run_episode(self, agent_state, rollout_idx=None):
+            t0 = _time.perf_counter()
+            await asyncio.sleep(0.05)  # simulate sampling
+            t1 = _time.perf_counter()
+            timings.append((self._name, t0, t1))
+            return f"ep_{self._name}"
+
+    envs = {f"t_{i}": _StubEnv(f"t_{i}") for i in range(8)}
+    adapter = OpenSpielGameAdapter(envs)
+    task_ids = [f"t_{i}" for i in range(8)]
+
+    t0 = _time.perf_counter()
+    eps = adapter.run_episodes_batch(task_ids, agent_state=object())
+    wall = _time.perf_counter() - t0
+
+    assert eps == [f"ep_t_{i}" for i in range(8)]
+    # Concurrent: wall < sum of individual waits. 8 * 0.05 = 0.4s serial;
+    # expect wall < 0.2s with any real async speedup.
+    assert wall < 0.25, f"expected concurrent speedup, got wall={wall:.3f}s"
+
+
+def test_config_defaults():
+    from clawloop.environments.openspiel import OpenSpielTaskConfig
+    cfg = OpenSpielTaskConfig(game_name="blackjack", seeds=[0, 1])
+    assert cfg.prompt_style == "canonical"
+    assert cfg.rethink_k == 3
+    assert cfg.max_turns == 50
+    assert cfg.temperature == 1.0
+    assert cfg.top_p == 0.95
+    assert cfg.max_tokens == 128
+    assert cfg.opponent is None
+
+
+def test_task_env_task_id_format():
+    from clawloop.environments.openspiel import (
+        OpenSpielTaskConfig, OpenSpielTaskEnvironment,
+    )
+    cfg = OpenSpielTaskConfig(game_name="blackjack", seeds=[0])
+    env = OpenSpielTaskEnvironment(cfg, seed=7)
+    assert env.task_id == "blackjack_seed_7"
+
+
+def test_task_env_exposes_seed_and_config():
+    from clawloop.environments.openspiel import (
+        OpenSpielTaskConfig, OpenSpielTaskEnvironment,
+    )
+    cfg = OpenSpielTaskConfig(game_name="chess", seeds=[3])
+    env = OpenSpielTaskEnvironment(cfg, seed=3)
+    assert env.seed == 3
+    assert env.config is cfg
+
+
+def test_adapter_stores_envs_keyed_by_task_id():
+    from clawloop.environments.openspiel import (
+        OpenSpielGameAdapter, OpenSpielTaskConfig, OpenSpielTaskEnvironment,
+    )
+    cfg = OpenSpielTaskConfig(game_name="blackjack", seeds=[0, 1])
+    envs = {
+        "blackjack_seed_0": OpenSpielTaskEnvironment(cfg, seed=0),
+        "blackjack_seed_1": OpenSpielTaskEnvironment(cfg, seed=1),
+    }
+    adapter = OpenSpielGameAdapter(envs)
+    assert "blackjack_seed_0" in adapter._envs_by_task_id
+    assert "blackjack_seed_1" in adapter._envs_by_task_id
+
+
+# ---------------------------------------------------------------------------
+# Task 12: prompt-building / move-parsing helpers.
+# ---------------------------------------------------------------------------
+
+
+def _fake_blackjack_state():
+    s = MagicMock()
+    s.current_player.return_value = 0
+    s.observation_string.return_value = "Hand: 10, 7. Dealer shows: 5."
+    s.legal_actions.return_value = [0, 1]
+    s.action_to_string.side_effect = lambda p, a: {0: "Hit", 1: "Stand"}[a]
+    return s
+
+
+def test_prompt_fallback_includes_observation_and_legal_actions():
+    from clawloop.environments.openspiel import _prompt_fallback
+    state = _fake_blackjack_state()
+    prompt = _prompt_fallback(state, history=[], style="canonical")
+    assert "Hand: 10, 7" in prompt
+    assert "Hit" in prompt
+    assert "Stand" in prompt
+    assert "Final Answer" in prompt
+
+
+def test_parse_move_fallback_final_answer_form():
+    from clawloop.environments.openspiel import _parse_move_fallback
+    state = _fake_blackjack_state()
+    assert _parse_move_fallback("Final Answer: Hit", state) == 0
+    assert _parse_move_fallback("final answer: stand", state) == 1
+
+
+def test_parse_move_fallback_free_form_match():
+    from clawloop.environments.openspiel import _parse_move_fallback
+    state = _fake_blackjack_state()
+    assert _parse_move_fallback("I think I'll Hit now.", state) == 0
+    assert _parse_move_fallback("Better to stand.", state) == 1
+
+
+def test_parse_move_fallback_returns_none_on_gibberish():
+    from clawloop.environments.openspiel import _parse_move_fallback
+    state = _fake_blackjack_state()
+    assert _parse_move_fallback("some unrelated text xyzzy", state) is None
+
+
+def test_parse_move_fallback_longest_match_preferred():
+    """If a shorter legal string is a substring of a longer one, prefer the longest."""
+    from clawloop.environments.openspiel import _parse_move_fallback
+    state = MagicMock()
+    state.current_player.return_value = 0
+    state.legal_actions.return_value = [0, 1]
+    state.action_to_string.side_effect = lambda p, a: {0: "Call", 1: "Call Bluff"}[a]
+    # "Call Bluff" contains "Call" — longest-match must win.
+    assert _parse_move_fallback("Final Answer: Call Bluff", state) == 1
+
+
+def test_build_prompt_uses_fallback_when_game_arena_unavailable(monkeypatch):
+    """When game_arena raises on import, build_prompt must return the fallback prompt."""
+    from clawloop.environments.openspiel import build_prompt
+    # game_arena IS installed, but we simulate it failing by patching _prompt_via_game_arena to None.
+    import clawloop.environments.openspiel as osp
+    monkeypatch.setattr(osp, "_prompt_via_game_arena", lambda *a, **kw: None)
+    state = _fake_blackjack_state()
+    prompt = build_prompt(state, history=[], style="canonical")
+    assert "Hand: 10, 7" in prompt   # fallback content
+
+
+def test_parse_move_uses_fallback_when_game_arena_unavailable(monkeypatch):
+    from clawloop.environments.openspiel import parse_move
+    # Force fallback by patching game_arena parser call to raise.
+    import clawloop.environments.openspiel as osp
+    def _raise(*a, **kw):
+        raise ImportError("no game_arena")
+    # The function tries to `from game_arena.harness import parsers` inside.
+    # Patch sys.modules so the import fails.
+    import sys
+    monkeypatch.setitem(sys.modules, "game_arena.harness", None)
+    state = _fake_blackjack_state()
+    assert parse_move("Final Answer: Hit", state) == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 13: run_episode.
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_agent_state(
+    *, sampling_client, renderer, tokenizer,
+):
+    """Build a minimal stand-in for AgentState.
+
+    Using a plain object instead of the real AgentState avoids coupling this
+    test to the loop module while still exposing the attributes run_episode
+    reads.
+    """
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        sampling_client=sampling_client,
+        renderer=renderer,
+        tokenizer=tokenizer,
+    )
+
+
+def _make_fake_sampling(tokens, logprobs):
+    """Build a sampling client whose .sample() returns a REAL concurrent.futures.Future.
+
+    Real future is required because run_episode now uses ``asyncio.wrap_future``
+    which asserts ``isinstance(f, concurrent.futures.Future)``.
+    """
+    import concurrent.futures
+    fake_seq = MagicMock()
+    fake_seq.tokens = tokens
+    fake_seq.logprobs = logprobs
+    fake_seq.stop_reason = "stop"
+    fake_response = MagicMock()
+    fake_response.sequences = [fake_seq]
+
+    fake_sampling = MagicMock()
+
+    def _sample(**_kwargs):
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        fut.set_result(fake_response)
+        return fut
+
+    fake_sampling.sample.side_effect = _sample
+    return fake_sampling
+
+
+@pytest.mark.asyncio
+async def test_run_episode_blackjack_terminates_and_captures_reward():
+    """Run a full Blackjack episode with a mocked sampler that always says 'Stand'."""
+    from clawloop.environments import openspiel as osp
+
+    fake_tokenizer = MagicMock()
+    fake_tokenizer.apply_chat_template.return_value = [1, 2, 3]
+    fake_tokenizer.decode.return_value = "Final Answer: Stand"
+    # Renderer without build_generation_prompt -> force the fallback via tokenizer.
+    fake_renderer = MagicMock(spec=[])
+
+    fake_sampling = _make_fake_sampling(
+        tokens=[10, 11, 12], logprobs=[-0.1, -0.2, -0.3],
+    )
+
+    cfg = osp.OpenSpielTaskConfig(
+        game_name="blackjack", seeds=[0], max_turns=10, max_tokens=8,
+    )
+    env = osp.OpenSpielTaskEnvironment(cfg, seed=0)
+    agent_state = _make_fake_agent_state(
+        sampling_client=fake_sampling,
+        renderer=fake_renderer,
+        tokenizer=fake_tokenizer,
+    )
+    episode = await env.run_episode(agent_state)
+
+    # Standing with the seed=0 initial hand ends the episode; effective reward
+    # in Blackjack is in {-1, 0, 1}.
+    assert episode.task_id == "blackjack_seed_0"
+    assert episode.summary.effective_reward() in (-1.0, 0.0, 1.0)
+    llm_steps = [s for s in episode.steps if "prompt_tokens" in s.info]
+    assert len(llm_steps) >= 1
+    for s in llm_steps:
+        assert len(s.info["sampled_tokens"]) == len(s.info["sampling_logprobs"])
+    # Illegal parse was not triggered.
+    ip = episode.summary.signals.get("illegal_parse")
+    if ip is not None:
+        assert ip.value == 0.0 or ip == 0.0
+    # Terminal StepMeta carries the final reward and done=True.
+    assert episode.steps[-1].done is True
+
+
+@pytest.mark.asyncio
+async def test_run_episode_illegal_parse_terminates_with_zero_reward():
+    """Unparseable responses across all retries -> reward 0 + illegal_parse signal."""
+    from clawloop.environments import openspiel as osp
+
+    fake_tokenizer = MagicMock()
+    fake_tokenizer.apply_chat_template.return_value = [1]
+    fake_tokenizer.decode.return_value = "totally unparseable gibberish xyzzy"
+    fake_renderer = MagicMock(spec=[])
+
+    fake_sampling = _make_fake_sampling(tokens=[99], logprobs=[-0.5])
+
+    cfg = osp.OpenSpielTaskConfig(
+        game_name="blackjack", seeds=[0], max_turns=10, max_tokens=8, rethink_k=1,
+    )
+    env = osp.OpenSpielTaskEnvironment(cfg, seed=0)
+    agent_state = _make_fake_agent_state(
+        sampling_client=fake_sampling,
+        renderer=fake_renderer,
+        tokenizer=fake_tokenizer,
+    )
+    episode = await env.run_episode(agent_state)
+
+    assert episode.summary.signals.get("illegal_parse") is not None
+    # Final reward is 0.0 — neither illegal penalty nor actual game return.
+    assert episode.summary.effective_reward() == 0.0
+    assert episode.steps[-1].done is True
+    assert episode.steps[-1].info.get("illegal_after_retries") is True
+
+
+@pytest.mark.asyncio
+async def test_run_episode_requires_sampling_client():
+    from clawloop.environments import openspiel as osp
+
+    cfg = osp.OpenSpielTaskConfig(game_name="blackjack", seeds=[0])
+    env = osp.OpenSpielTaskEnvironment(cfg, seed=0)
+    agent_state = _make_fake_agent_state(
+        sampling_client=None, renderer=MagicMock(), tokenizer=MagicMock(),
+    )
+    with pytest.raises(RuntimeError, match="sampling_client"):
+        await env.run_episode(agent_state)
+
+
+@pytest.mark.asyncio
+async def test_run_episode_requires_renderer_and_tokenizer():
+    from clawloop.environments import openspiel as osp
+
+    cfg = osp.OpenSpielTaskConfig(game_name="blackjack", seeds=[0])
+    env = osp.OpenSpielTaskEnvironment(cfg, seed=0)
+    agent_state = _make_fake_agent_state(
+        sampling_client=MagicMock(), renderer=None, tokenizer=None,
+    )
+    with pytest.raises(RuntimeError, match="renderer"):
+        await env.run_episode(agent_state)

--- a/tests/unit/test_train.py
+++ b/tests/unit/test_train.py
@@ -1,0 +1,149 @@
+"""Unit tests for env_type=openspiel + weight_backend=tinker wiring in train.py."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_build_openspiel_tasks_repeat_per_seed():
+    from clawloop.train import ENV_BUILDERS, TrainConfig
+    cfg = TrainConfig(
+        mode="weight",
+        env_type="openspiel",
+        weight_backend="tinker",
+        openspiel={
+            "game_name": "blackjack",
+            "seeds": [0, 1],
+            "episodes_per_seed": 4,
+        },
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+        n_iterations=1,
+    )
+    builder = ENV_BUILDERS["openspiel"]
+    adapter, tasks = builder(cfg, cfg.llm_clients)
+    assert len(tasks) == 8
+    assert tasks.count("blackjack_seed_0") == 4
+    assert tasks.count("blackjack_seed_1") == 4
+    # Adapter dispatches by task_id.
+    assert "blackjack_seed_0" in adapter._envs_by_task_id
+    assert "blackjack_seed_1" in adapter._envs_by_task_id
+
+
+def test_effective_episodes_per_iter_for_openspiel_single_game():
+    from clawloop.train import TrainConfig, effective_episodes_per_iter
+    cfg = TrainConfig(
+        mode="weight",
+        env_type="openspiel",
+        weight_backend="tinker",
+        openspiel={
+            "game_name": "blackjack",
+            "seeds": [0, 1, 2],
+            "episodes_per_seed": 5,
+        },
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+        n_iterations=1,
+    )
+    # Validator must NOT mutate the user's config — the derived count comes
+    # from effective_episodes_per_iter, not a side effect.
+    assert effective_episodes_per_iter(cfg) == 15   # 3 seeds * 5 per seed
+
+
+def test_build_openspiel_mixed_games_interleaves_tasks():
+    """`openspiel.games: [...]` -> envs from multiple games, task_id preserves
+    `{game}_seed_{n}` so GRPO grouping stays per-(game, seed)."""
+    from clawloop.train import ENV_BUILDERS, TrainConfig
+    cfg = TrainConfig(
+        mode="weight",
+        env_type="openspiel",
+        weight_backend="tinker",
+        openspiel={
+            "games": [
+                {"game_name": "blackjack", "seeds": [0, 1], "episodes_per_seed": 3, "max_turns": 10},
+                {"game_name": "2048",      "seeds": [10, 11], "episodes_per_seed": 2, "max_turns": 200},
+            ],
+            "temperature": 1.0, "top_p": 0.95, "max_tokens": 64,
+        },
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+        n_iterations=1,
+    )
+    builder = ENV_BUILDERS["openspiel"]
+    adapter, tasks = builder(cfg, cfg.llm_clients)
+    # 2 blackjack seeds * 3 + 2 2048 seeds * 2 = 10
+    assert len(tasks) == 10
+    assert tasks.count("blackjack_seed_0") == 3
+    assert tasks.count("blackjack_seed_1") == 3
+    assert tasks.count("2048_seed_10") == 2
+    assert tasks.count("2048_seed_11") == 2
+    assert set(adapter._envs_by_task_id.keys()) == {
+        "blackjack_seed_0", "blackjack_seed_1", "2048_seed_10", "2048_seed_11",
+    }
+
+
+def test_effective_episodes_per_iter_for_mixed_games():
+    from clawloop.train import TrainConfig, effective_episodes_per_iter
+    cfg = TrainConfig(
+        mode="weight", env_type="openspiel", weight_backend="tinker",
+        openspiel={
+            "games": [
+                {"game_name": "blackjack", "seeds": [0, 1, 2], "episodes_per_seed": 4},
+                {"game_name": "2048", "seeds": [0, 1], "episodes_per_seed": 3},
+            ],
+        },
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+    )
+    # (3 * 4) + (2 * 3) = 18
+    assert effective_episodes_per_iter(cfg) == 18
+
+
+def test_validate_config_rejects_mixed_game_without_game_name():
+    from clawloop.train import TrainConfig, validate_config
+    cfg = TrainConfig(
+        mode="weight", env_type="openspiel", weight_backend="tinker",
+        openspiel={"games": [{"seeds": [0]}]},
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+    )
+    with pytest.raises(ValueError, match="game_name"):
+        validate_config(cfg)
+
+
+def test_validate_config_rejects_openspiel_without_game_name():
+    from clawloop.train import TrainConfig, validate_config
+    cfg = TrainConfig(
+        mode="weight", env_type="openspiel", weight_backend="tinker",
+        openspiel={"seeds": [0, 1]},
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+    )
+    with pytest.raises(ValueError, match="game_name"):
+        validate_config(cfg)
+
+
+def test_validate_config_rejects_empty_seeds():
+    from clawloop.train import TrainConfig, validate_config
+    cfg = TrainConfig(
+        mode="weight", env_type="openspiel", weight_backend="tinker",
+        openspiel={"game_name": "blackjack", "seeds": []},
+        tinker={"base_model": "Qwen/Qwen3-8B"},
+    )
+    with pytest.raises(ValueError, match="seeds"):
+        validate_config(cfg)
+
+
+def test_validate_config_requires_tinker_config_when_backend_tinker():
+    from clawloop.train import TrainConfig, validate_config
+    cfg = TrainConfig(
+        mode="weight", env_type="openspiel", weight_backend="tinker",
+        openspiel={"game_name": "blackjack", "seeds": [0]},
+        tinker=None,
+    )
+    with pytest.raises(ValueError, match="tinker"):
+        validate_config(cfg)
+
+
+def test_validate_config_requires_skyrl_config_when_backend_skyrl():
+    from clawloop.train import TrainConfig, validate_config
+    cfg = TrainConfig(
+        mode="weight", env_type="openspiel", weight_backend="skyrl",
+        openspiel={"game_name": "blackjack", "seeds": [0]},
+        skyrl=None,
+    )
+    with pytest.raises(ValueError, match="skyrl"):
+        validate_config(cfg)

--- a/tests/unit/weight_backends/test_tinker_backend.py
+++ b/tests/unit/weight_backends/test_tinker_backend.py
@@ -1,0 +1,585 @@
+"""Unit tests for TinkerWeightsConfig dataclass and TinkerWeightsBackend.
+
+These tests verify the config holds non-secret fields only, has the
+preflight-verified defaults, and never accidentally serializes credentials.
+The backend tests cover __init__ + current_sampling_client (Task 8) and
+the Layer-protocol methods (Task 9); they must NOT hit the network — every
+Tinker SDK call is monkey-patched.
+"""
+from dataclasses import asdict
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# tinker / tinker_cookbook are optional extras (pyproject.toml [games]).
+# Skip the whole module on CI runs that don't install them.
+pytest.importorskip("tinker")
+pytest.importorskip("tinker_cookbook")
+
+from clawloop.core.types import Datum, SampleContext
+from clawloop.weight_backends._tinker_sdk import TinkerBackendError
+from clawloop.weight_backends.base import BackendError
+from clawloop.weight_backends.tinker import TinkerWeightsConfig
+
+
+def test_config_defaults():
+    cfg = TinkerWeightsConfig(base_model="Qwen/Qwen3-8B")
+    assert cfg.lora_rank == 8
+    assert cfg.seed == 42
+    assert cfg.train_attn is True
+    assert cfg.train_mlp is True
+    assert cfg.train_unembed is False
+    assert cfg.loss_fn == "importance_sampling"
+    # Verify adam_params has exactly the 4 supported keys.
+    assert set(cfg.adam_params.keys()) == {"learning_rate", "beta1", "beta2", "eps"}
+    assert "weight_decay" not in cfg.adam_params
+
+
+def test_config_merges_partial_adam_params_with_defaults():
+    """User-supplied ``adam_params={"learning_rate": 5e-6}`` keeps the other
+    three required keys (beta1, beta2, eps) — otherwise ``AdamParams(**...)``
+    would TypeError at optim_step time."""
+    from clawloop.weight_backends.tinker import TinkerWeightsConfig
+    cfg = TinkerWeightsConfig(
+        base_model="Qwen/Qwen3-8B",
+        adam_params={"learning_rate": 5e-6},
+    )
+    # All four required AdamParams kwargs present after the merge.
+    assert cfg.adam_params["learning_rate"] == 5e-6   # user override kept
+    assert cfg.adam_params["beta1"] == 0.9            # default filled in
+    assert cfg.adam_params["beta2"] == 0.999
+    assert cfg.adam_params["eps"] == 1e-8
+
+
+def test_config_has_no_secret_fields():
+    cfg = TinkerWeightsConfig(base_model="Qwen/Qwen3-8B")
+    assert not hasattr(cfg, "api_key")
+    assert not hasattr(cfg, "tinker_api_key")
+
+
+def test_config_serialization_has_no_secrets():
+    cfg = TinkerWeightsConfig(base_model="Qwen/Qwen3-8B")
+    serialized = str(asdict(cfg)).lower()
+    for forbidden in ("api_key", "secret", "token", "bearer"):
+        assert forbidden not in serialized, f"{forbidden} found in config dict"
+
+
+# ---------------------------------------------------------------------------
+# TinkerWeightsBackend (Task 8): __init__ + current_sampling_client
+# ---------------------------------------------------------------------------
+
+
+def test_init_fails_without_api_key(monkeypatch):
+    """Constructor must raise TinkerBackendError(missing_api_key) when env is unset."""
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+    # Block all three lookup paths in clawloop.config.load_env so the real
+    # clawloop/.env (which exists locally) cannot satisfy the check.
+    monkeypatch.setenv("CLAWLOOP_ENV_FILE", "/nonexistent/path")
+    monkeypatch.chdir("/tmp")
+    import clawloop.config
+    clawloop.config._loaded = False
+    # Belt-and-braces: also no-op the load_env reference inside tinker.py so
+    # the package-scoped clawloop/.env can never be picked up.
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.load_env", lambda: []
+    )
+
+    from clawloop.weight_backends.tinker import (
+        TinkerWeightsBackend,
+        TinkerWeightsConfig,
+    )
+    from clawloop.weight_backends._tinker_sdk import TinkerBackendError
+
+    with pytest.raises(TinkerBackendError) as excinfo:
+        TinkerWeightsBackend(TinkerWeightsConfig(base_model="Qwen/Qwen3-8B"))
+    assert excinfo.value.code == "missing_api_key"
+
+
+def test_init_creates_training_and_sampling_clients(monkeypatch):
+    """Verify constructor wires service/training/sampling/tokenizer/renderer."""
+    monkeypatch.setenv("TINKER_API_KEY", "fake")
+
+    fake_service = SimpleNamespace(name="service")
+    fake_tokenizer = SimpleNamespace(name="tokenizer")
+    fake_training = SimpleNamespace(
+        get_tokenizer=lambda: fake_tokenizer,
+    )
+    fake_sampling = SimpleNamespace(name="sampling")
+    fake_renderer = SimpleNamespace(name="renderer")
+
+    create_training_calls: list[dict] = []
+    create_sampling_calls: list[dict] = []
+    get_renderer_calls: list[str] = []
+    recommended_calls: list[str] = []
+
+    def _make_service():
+        return fake_service
+
+    def _create_training(service, **kwargs):
+        assert service is fake_service
+        create_training_calls.append(kwargs)
+        return fake_training
+
+    def _create_sampling(service, **kwargs):
+        assert service is fake_service
+        create_sampling_calls.append(kwargs)
+        return fake_sampling
+
+    def _get_renderer(name, tokenizer):
+        get_renderer_calls.append(name)
+        return fake_renderer
+
+    def _recommended(model):
+        recommended_calls.append(model)
+        return "qwen3"
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.make_service_client",
+        _make_service,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_training",
+        _create_training,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_sampling",
+        _create_sampling,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.make_rest_client",
+        lambda service: SimpleNamespace(name="rest"),
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.get_model_id",
+        lambda training: "fake-model-id",
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.get_renderer", _get_renderer
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.get_recommended_renderer_name",
+        _recommended,
+    )
+
+    from clawloop.weight_backends.tinker import (
+        TinkerWeightsBackend,
+        TinkerWeightsConfig,
+    )
+
+    cfg = TinkerWeightsConfig(
+        base_model="Qwen/Qwen3-8B",
+        lora_rank=16,
+        seed=7,
+        train_attn=True,
+        train_mlp=False,
+        train_unembed=True,
+    )
+    backend = TinkerWeightsBackend(cfg)
+
+    # create_training was called with full kwargs.
+    assert len(create_training_calls) == 1
+    kw = create_training_calls[0]
+    assert kw["base_model"] == "Qwen/Qwen3-8B"
+    assert kw["rank"] == 16
+    assert kw["seed"] == 7
+    assert kw["train_attn"] is True
+    assert kw["train_mlp"] is False
+    assert kw["train_unembed"] is True
+
+    # create_sampling was called with base_model= (not model_path=).
+    assert len(create_sampling_calls) == 1
+    skw = create_sampling_calls[0]
+    assert skw.get("base_model") == "Qwen/Qwen3-8B"
+    assert "model_path" not in skw
+
+    # Renderer auto-selected via get_recommended_renderer_name.
+    assert recommended_calls == ["Qwen/Qwen3-8B"]
+    assert get_renderer_calls == ["qwen3"]
+
+    # Accessors expose what __init__ cached.
+    assert backend.current_sampling_client() is fake_sampling
+    assert backend.renderer is fake_renderer
+    assert backend.tokenizer is fake_tokenizer
+    assert backend.config is cfg
+
+
+def test_init_uses_explicit_renderer_name_when_provided(monkeypatch):
+    """If config.renderer_name is set, it overrides the recommended lookup."""
+    monkeypatch.setenv("TINKER_API_KEY", "fake")
+
+    fake_service = SimpleNamespace()
+    fake_training = SimpleNamespace(get_tokenizer=lambda: SimpleNamespace())
+    fake_sampling = SimpleNamespace()
+
+    recommended_calls: list[str] = []
+    get_renderer_calls: list[str] = []
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.make_service_client",
+        lambda: fake_service,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_training",
+        lambda service, **kw: fake_training,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_sampling",
+        lambda service, **kw: fake_sampling,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.make_rest_client",
+        lambda service: SimpleNamespace(name="rest"),
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.get_model_id",
+        lambda training: "fake-model-id",
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.get_recommended_renderer_name",
+        lambda m: recommended_calls.append(m) or "should-not-be-used",
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.get_renderer",
+        lambda name, tokenizer: get_renderer_calls.append(name) or SimpleNamespace(),
+    )
+
+    from clawloop.weight_backends.tinker import (
+        TinkerWeightsBackend,
+        TinkerWeightsConfig,
+    )
+
+    cfg = TinkerWeightsConfig(
+        base_model="Qwen/Qwen3-8B", renderer_name="custom-renderer"
+    )
+    TinkerWeightsBackend(cfg)
+
+    assert recommended_calls == []
+    assert get_renderer_calls == ["custom-renderer"]
+
+
+# ---------------------------------------------------------------------------
+# TinkerWeightsBackend (Task 9): Layer-protocol methods
+# ---------------------------------------------------------------------------
+
+
+def _fake_backend(monkeypatch):
+    """Build a TinkerWeightsBackend with every SDK call mocked.
+
+    Returns ``(backend, fake_training, fake_sampling)``. All Tinker SDK
+    entry points and the renderer/tokenizer factories are monkeypatched
+    so no network or model files are touched.
+    """
+    monkeypatch.setenv("TINKER_API_KEY", "fake")
+    # Don't let load_env clobber our env var.
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.load_env", lambda: []
+    )
+
+    fake_service = SimpleNamespace(name="service")
+    fake_tokenizer = SimpleNamespace(name="tokenizer")
+    fake_training = SimpleNamespace(get_tokenizer=lambda: fake_tokenizer)
+    fake_sampling = SimpleNamespace(name="sampling-base")
+    fake_renderer = SimpleNamespace(name="renderer")
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.make_service_client",
+        lambda: fake_service,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_training",
+        lambda service, **kw: fake_training,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_sampling",
+        lambda service, **kw: fake_sampling,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.make_rest_client",
+        lambda service: SimpleNamespace(name="rest"),
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.get_model_id",
+        lambda training: "fake-model-id",
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.get_renderer",
+        lambda name, tokenizer: fake_renderer,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.get_recommended_renderer_name",
+        lambda model: "qwen3",
+    )
+
+    from clawloop.weight_backends.tinker import (
+        TinkerWeightsBackend,
+        TinkerWeightsConfig,
+    )
+
+    cfg = TinkerWeightsConfig(base_model="Qwen/Qwen3-8B")
+    backend = TinkerWeightsBackend(cfg)
+    return backend, fake_training, fake_sampling
+
+
+# 1. forward_backward pipelines fb + optim, returns ok with n_datums
+def test_forward_backward_pipelines_fb_and_optim(monkeypatch):
+    backend, fake_training, _ = _fake_backend(monkeypatch)
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.episodes_to_tinker_datums",
+        lambda episodes, *, loss_fn: [MagicMock(name="datum")],
+    )
+
+    fb_future = MagicMock()
+    fb_future.result.return_value = {"loss": 0.5}
+    opt_future = MagicMock()
+    opt_future.result.return_value = {"step": 1}
+
+    fb_calls: list[dict] = []
+
+    def _fb(training, batch, *, loss_fn, loss_fn_config):
+        assert training is fake_training
+        fb_calls.append(
+            {
+                "batch_len": len(batch),
+                "loss_fn": loss_fn,
+                "loss_fn_config": loss_fn_config,
+            }
+        )
+        return fb_future
+
+    opt_calls: list[Any] = []
+
+    def _opt(training, adam_params):
+        assert training is fake_training
+        opt_calls.append(adam_params)
+        return opt_future
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.forward_backward", _fb
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.optim_step", _opt
+    )
+
+    result = backend.forward_backward(
+        Datum(episodes=[], loss_fn="importance_sampling")
+    ).result()
+
+    assert result.status == "ok"
+    assert result.metrics["n_datums"] == 1
+    assert len(fb_calls) == 1
+    assert fb_calls[0]["batch_len"] == 1
+    assert len(opt_calls) == 1
+    fb_future.result.assert_called_once()
+    opt_future.result.assert_called_once()
+
+
+# 2. forward_backward returns ok with no SDK call when exporter yields []
+def test_forward_backward_skips_when_no_datums(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.episodes_to_tinker_datums",
+        lambda episodes, *, loss_fn: [],
+    )
+
+    fb_called = []
+    opt_called = []
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.forward_backward",
+        lambda *a, **kw: fb_called.append(1) or MagicMock(),
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.optim_step",
+        lambda *a, **kw: opt_called.append(1) or MagicMock(),
+    )
+
+    result = backend.forward_backward(Datum(episodes=[])).result()
+
+    assert result.status == "ok"
+    assert result.metrics.get("n_datums") == 0
+    assert result.metrics.get("dropped") is True
+    assert fb_called == []
+    assert opt_called == []
+
+
+# 3. forward_backward catches TinkerBackendError and returns FBResult(error)
+def test_forward_backward_wraps_backend_error(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker.episodes_to_tinker_datums",
+        lambda episodes, *, loss_fn: [MagicMock(name="datum")],
+    )
+
+    err = TinkerBackendError(
+        BackendError(code="rate_limit", message="slow", recoverable=True)
+    )
+
+    def _raise(*a, **kw):
+        raise err
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.forward_backward", _raise
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.optim_step",
+        lambda *a, **kw: MagicMock(),
+    )
+
+    result = backend.forward_backward(Datum(episodes=[])).result()
+
+    assert result.status == "error"
+    assert "error" in result.metrics
+    assert result.metrics["error"]["code"] == "rate_limit"
+    assert result.metrics["error"]["recoverable"] is True
+
+
+# 4. save_state swaps the SamplingClient and appends to _adapter_paths
+def test_save_state_swaps_sampling_client_and_appends_path(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    new_client = SimpleNamespace(name="sampling-after-save")
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.save_weights_and_get_sampling_client",
+        lambda training, name: new_client,
+    )
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.save_state_durable",
+        lambda training, name, ttl_seconds=None: f"tinker://ckpt/{name}",
+    )
+
+    out = backend.save_state("iter_0").result()
+
+    assert out.status == "ok"
+    assert out.name == "iter_0"
+    assert backend.current_sampling_client() is new_client
+    assert backend._adapter_paths == ["iter_0"]
+    assert backend._durable_paths == ["tinker://ckpt/iter_0"]
+
+
+# 5. load_state with no adapter_paths is a successful no-op
+def test_load_state_with_no_adapter_paths_is_ok(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    load_calls: list[Any] = []
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.load_state_with_optimizer",
+        lambda training, path: load_calls.append(path),
+    )
+
+    out = backend.load_state({}).result()
+    assert out.status == "ok"
+    assert load_calls == []
+
+
+# 6. load_state restores from the LAST entry of adapter_paths
+def test_load_state_restores_from_last_path(monkeypatch):
+    backend, fake_training, _ = _fake_backend(monkeypatch)
+
+    load_calls: list[tuple[Any, str]] = []
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.load_state_with_optimizer",
+        lambda training, path: load_calls.append((training, path)),
+    )
+
+    new_client = SimpleNamespace(name="sampling-after-load")
+    create_calls: list[dict] = []
+
+    def _create_sampling(service, **kwargs):
+        create_calls.append(kwargs)
+        return new_client
+
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.create_sampling",
+        _create_sampling,
+    )
+
+    # load_state prefers durable_paths (tinker:// URIs) over ephemeral names.
+    out = backend.load_state(
+        {
+            "adapter_paths": ["iter_0", "iter_1"],
+            "durable_paths": ["tinker://ckpt-0", "tinker://ckpt-1"],
+        }
+    ).result()
+
+    assert out.status == "ok"
+    assert load_calls == [(fake_training, "tinker://ckpt-1")]
+    assert len(create_calls) == 1
+    assert create_calls[0].get("model_path") == "tinker://ckpt-1"
+    assert backend._adapter_paths == ["iter_0", "iter_1"]
+    assert backend._durable_paths == ["tinker://ckpt-0", "tinker://ckpt-1"]
+    assert backend.current_sampling_client() is new_client
+
+
+# 7. optim_step is a no-op (already submitted+awaited inside forward_backward)
+def test_optim_step_is_noop(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    sdk_called = []
+    monkeypatch.setattr(
+        "clawloop.weight_backends.tinker._tinker_sdk.optim_step",
+        lambda *a, **kw: sdk_called.append(1) or MagicMock(),
+    )
+
+    out = backend.optim_step().result()
+    assert out.status == "ok"
+    assert out.updates_applied == 1
+    assert sdk_called == []
+
+
+# 8. sample returns base_model when no adapter has been saved
+def test_sample_returns_base_model_when_no_adapter(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    out = backend.sample(SampleContext(bench="test")).result()
+    assert out.output == "Qwen/Qwen3-8B"
+
+
+# 9. sample returns the LATEST adapter path when one is available
+def test_sample_returns_latest_adapter_path_when_available(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+    backend._adapter_paths = ["iter_0", "iter_1"]
+
+    out = backend.sample(SampleContext(bench="test")).result()
+    assert out.output == "iter_1"
+
+
+# 10. to_dict has no secret keys (or values)
+def test_to_dict_has_no_secret_keys(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+
+    d = backend.to_dict()
+    blob = str(d).lower()
+    for forbidden in ("api_key", "secret", "bearer", "token"):
+        assert forbidden not in blob, f"{forbidden} leaked into to_dict()"
+        assert all(forbidden not in str(k).lower() for k in d.keys()), (
+            f"{forbidden} appeared as a key in to_dict()"
+        )
+
+
+# 11. to_dict contains the expected config + adapter_paths
+def test_to_dict_contains_expected_config_and_adapter_paths(monkeypatch):
+    backend, _, _ = _fake_backend(monkeypatch)
+    backend._adapter_paths = ["iter_0"]
+
+    d = backend.to_dict()
+    assert d["base_model"] == "Qwen/Qwen3-8B"
+    assert d["lora_rank"] == 8
+    assert d["adapter_paths"] == ["iter_0"]
+    # All required keys are present.
+    for key in (
+        "base_model",
+        "lora_rank",
+        "seed",
+        "train_attn",
+        "train_mlp",
+        "train_unembed",
+        "loss_fn",
+        "loss_fn_config",
+        "adam_params",
+        "adapter_paths",
+    ):
+        assert key in d, f"missing key {key!r} in to_dict()"

--- a/tests/unit/weight_backends/test_tinker_exporter.py
+++ b/tests/unit/weight_backends/test_tinker_exporter.py
@@ -1,0 +1,227 @@
+"""Unit tests for ``_tinker_exporter.episodes_to_tinker_datums``.
+
+Tests verify episode-level GRPO grouping, exact-token alignment via
+``StepMeta.info`` keys (``prompt_tokens``/``sampled_tokens``/
+``sampling_logprobs``), prompt-position zero-padding, dtype contracts,
+and skip rules for non-LLM steps / singleton groups / zero-variance groups.
+
+No network access — Tinker types are local pydantic models.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# Optional extras (in pyproject.toml [games]); skip the whole module if
+# any are missing.  Order: check BEFORE the actual imports below.
+np = pytest.importorskip("numpy")
+pytest.importorskip("tinker")
+
+from clawloop.core.episode import (
+    Episode,
+    EpisodeSummary,
+    Message,
+    StepMeta,
+)
+from clawloop.weight_backends._tinker_exporter import (
+    episodes_to_tinker_datums,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+# A "turn" tuple is (prompt_tokens, sampled_tokens, sampling_logprobs).
+# A turn entry of ``None`` denotes a non-LLM step (CHANCE / opponent), which
+# yields a StepMeta with no prompt_tokens/sampled_tokens/sampling_logprobs in
+# its ``info`` dict — the exporter must skip such steps.
+TurnSpec = tuple[list[int], list[int], list[float]] | None
+
+
+def _make_episode(
+    task_id: str,
+    terminal_reward: float,
+    turns: list[TurnSpec],
+) -> Episode:
+    """Build an Episode with one StepMeta per turn entry.
+
+    ``terminal_reward`` is in [-1, 1] (canonical internal range).  It is set
+    via ``EpisodeSummary.total_reward`` (which expects [0, 1] and stores as
+    an outcome signal mapped to [-1, 1]); we therefore pre-convert.
+    """
+    steps: list[StepMeta] = []
+    for t, turn in enumerate(turns):
+        info: dict[str, Any] = {}
+        if turn is not None:
+            prompt_tokens, sampled_tokens, sampling_logprobs = turn
+            info["prompt_tokens"] = list(prompt_tokens)
+            info["sampled_tokens"] = list(sampled_tokens)
+            info["sampling_logprobs"] = list(sampling_logprobs)
+        steps.append(
+            StepMeta(t=t, reward=0.0, done=False, timing_ms=0.0, info=info)
+        )
+    if steps:
+        steps[-1].done = True
+        steps[-1].reward = terminal_reward
+
+    # ``EpisodeSummary.total_reward`` accepts [0, 1] and stores as outcome in
+    # [-1, 1].  Convert the canonical [-1, 1] terminal_reward back to [0, 1].
+    summary = EpisodeSummary(total_reward=(terminal_reward + 1.0) / 2.0)
+
+    return Episode(
+        id=Episode.new_id(),
+        state_id="state-x",
+        task_id=task_id,
+        bench="test",
+        messages=[Message(role="user", content="x")],
+        step_boundaries=[0],
+        steps=steps,
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_grpo_groups_by_task_id_and_broadcasts_advantage() -> None:
+    ep_a = _make_episode(
+        task_id="t1",
+        terminal_reward=1.0,
+        turns=[([10, 11, 12], [20, 21], [-0.1, -0.2])],
+    )
+    ep_b = _make_episode(
+        task_id="t1",
+        terminal_reward=-1.0,
+        turns=[([30, 31], [40], [-0.5])],
+    )
+
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+
+    assert len(datums) == 2
+    # ep_a -> +1, ep_b -> -1 (mean=0)
+    advs_a = list(datums[0].loss_fn_inputs["advantages"].data)
+    advs_b = list(datums[1].loss_fn_inputs["advantages"].data)
+    # ep_a: 3 prompt zeros + 2 completion +1's
+    assert advs_a == [0.0, 0.0, 0.0, 1.0, 1.0]
+    # ep_b: 2 prompt zeros + 1 completion -1
+    assert advs_b == [0.0, 0.0, -1.0]
+
+
+def test_grpo_skips_singleton_groups() -> None:
+    ep = _make_episode(
+        task_id="solo",
+        terminal_reward=0.5,
+        turns=[([1, 2], [3], [-0.3])],
+    )
+    assert episodes_to_tinker_datums([ep], loss_fn="importance_sampling") == []
+
+
+def test_grpo_skips_zero_variance_groups() -> None:
+    ep_a = _make_episode("t1", 0.5, [([1, 2], [3], [-0.1])])
+    ep_b = _make_episode("t1", 0.5, [([4, 5], [6], [-0.1])])
+    assert episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling") == []
+
+
+def test_one_datum_per_llm_turn() -> None:
+    # Two episodes, same task, each: LLM turn, CHANCE step, LLM turn.
+    turns_a: list[TurnSpec] = [
+        ([1, 2], [10, 11], [-0.1, -0.2]),
+        None,  # CHANCE
+        ([3, 4], [12], [-0.3]),
+    ]
+    turns_b: list[TurnSpec] = [
+        ([5, 6], [20], [-0.4]),
+        None,
+        ([7, 8], [21, 22], [-0.5, -0.6]),
+    ]
+    ep_a = _make_episode("t1", 1.0, turns_a)
+    ep_b = _make_episode("t1", -1.0, turns_b)
+
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+    assert len(datums) == 4  # 2 episodes * 2 LLM turns each
+
+
+def test_token_alignment_invariant() -> None:
+    ep_a = _make_episode("t1", 1.0, [([1, 2, 3], [9, 8], [-0.1, -0.2])])
+    ep_b = _make_episode("t1", -1.0, [([4], [7, 6, 5], [-0.3, -0.4, -0.5])])
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+    for d in datums:
+        # full token length from the model_input chunk
+        full_len = len(d.model_input.chunks[0].tokens)
+        assert len(d.loss_fn_inputs["target_tokens"].data) == full_len
+        assert len(d.loss_fn_inputs["logprobs"].data) == full_len
+        assert len(d.loss_fn_inputs["advantages"].data) == full_len
+
+
+def test_prompt_positions_zero_padded() -> None:
+    # n_prompt=3, n_comp=1
+    ep_a = _make_episode("t1", 1.0, [([1, 2, 3], [9], [-0.7])])
+    ep_b = _make_episode("t1", -1.0, [([4, 5, 6], [8], [-0.8])])
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+    d = datums[0]
+    target = list(d.loss_fn_inputs["target_tokens"].data)
+    lp = list(d.loss_fn_inputs["logprobs"].data)
+    advs = list(d.loss_fn_inputs["advantages"].data)
+    assert target[:3] == [0, 0, 0]
+    assert lp[:3] == [0.0, 0.0, 0.0]
+    assert advs[:3] == [0.0, 0.0, 0.0]
+    # ep_a advantage = 1 - mean(1, -1) = 1.0
+    assert advs[3] == 1.0
+    # last completion token == sampled token
+    assert target[3] == 9
+
+
+def test_dtypes_int64_and_float32() -> None:
+    ep_a = _make_episode("t1", 1.0, [([1, 2], [3], [-0.1])])
+    ep_b = _make_episode("t1", -1.0, [([4, 5], [6], [-0.2])])
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+    for d in datums:
+        # Tinker stores as TensorData with literal dtype strings; verify the
+        # serialized dtype labels match the int64/float32 contract.
+        assert d.loss_fn_inputs["target_tokens"].dtype == "int64"
+        assert d.loss_fn_inputs["logprobs"].dtype == "float32"
+        assert d.loss_fn_inputs["advantages"].dtype == "float32"
+
+
+def test_misaligned_logprobs_raises() -> None:
+    # sampled_tokens has 2 entries but sampling_logprobs has 3
+    ep_a = _make_episode("t1", 1.0, [([1], [2, 3], [-0.1, -0.2, -0.3])])
+    ep_b = _make_episode("t1", -1.0, [([4], [5], [-0.4])])
+    with pytest.raises(ValueError, match="alignment invariant"):
+        episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+
+
+def test_empty_completion_is_skipped_but_other_turns_emitted() -> None:
+    # ep_a has one empty-completion turn and one normal turn; ep_b has two normal turns.
+    ep_a = _make_episode(
+        "t1",
+        1.0,
+        [
+            ([1, 2], [], []),                  # empty -> skipped
+            ([3, 4], [99], [-0.7]),            # normal
+        ],
+    )
+    ep_b = _make_episode(
+        "t1",
+        -1.0,
+        [
+            ([5, 6], [88], [-0.5]),
+            ([7, 8], [77], [-0.6]),
+        ],
+    )
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+    # ep_a contributes 1 datum, ep_b contributes 2 -> 3 total
+    assert len(datums) == 3
+
+
+def test_skips_non_llm_steps_without_prompt_tokens_key() -> None:
+    # Both episodes are entirely non-LLM (CHANCE) — even with reward variance
+    # there are no LLM turns, so zero datums.
+    ep_a = _make_episode("t1", 1.0, [None, None])
+    ep_b = _make_episode("t1", -1.0, [None, None])
+    datums = episodes_to_tinker_datums([ep_a, ep_b], loss_fn="importance_sampling")
+    assert datums == []

--- a/tests/unit/weight_backends/test_tinker_sdk.py
+++ b/tests/unit/weight_backends/test_tinker_sdk.py
@@ -1,0 +1,295 @@
+"""Unit tests for the Tinker SDK thin adapter.
+
+Every Tinker SDK call is mocked — no network access is required.  Tests cover
+signature correctness, error-taxonomy wrapping, and structural checks on the
+``ModelInput`` / ``SamplingParams`` objects built by ``async_sample``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# tinker is an optional extra (see pyproject.toml [games]); skip the whole
+# module in CI runs that don't install it.
+tinker = pytest.importorskip("tinker")
+tinker_types = pytest.importorskip("tinker.types")
+
+from clawloop.weight_backends import _tinker_sdk
+from clawloop.weight_backends._tinker_sdk import (
+    TinkerBackendError,
+    async_sample,
+    create_sampling,
+    create_training,
+    forward_backward,
+    load_state_with_optimizer,
+    make_service_client,
+    optim_step,
+    save_weights_and_get_sampling_client,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. make_service_client reads env
+# ---------------------------------------------------------------------------
+
+def test_make_service_client_reads_env(monkeypatch):
+    monkeypatch.setenv("TINKER_API_KEY", "test-key-123")
+    fake_client = MagicMock()
+    with patch.object(tinker, "ServiceClient", return_value=fake_client) as ctor:
+        got = make_service_client()
+    assert got is fake_client
+    ctor.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# 2. create_training forwards kwargs
+# ---------------------------------------------------------------------------
+
+def test_create_training_passes_kwargs():
+    service = MagicMock()
+    create_training(
+        service,
+        base_model="meta-llama/Llama-3.2-1B",
+        rank=8,
+        seed=42,
+        train_attn=True,
+        train_mlp=False,
+        train_unembed=True,
+    )
+    service.create_lora_training_client.assert_called_once_with(
+        base_model="meta-llama/Llama-3.2-1B",
+        rank=8,
+        seed=42,
+        train_attn=True,
+        train_mlp=False,
+        train_unembed=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. create_sampling: exactly-one-of validation
+# ---------------------------------------------------------------------------
+
+def test_create_sampling_requires_exactly_one_ref():
+    service = MagicMock()
+
+    with pytest.raises(ValueError):
+        create_sampling(service)  # neither
+
+    with pytest.raises(ValueError):
+        create_sampling(service, base_model="x", model_path="y")  # both
+
+
+# ---------------------------------------------------------------------------
+# 4. create_sampling forwards base_model + retry_config
+# ---------------------------------------------------------------------------
+
+def test_create_sampling_base_model_path():
+    service = MagicMock()
+    retry = object()
+    create_sampling(service, base_model="meta-llama/Llama-3.2-1B", retry_config=retry)
+    service.create_sampling_client.assert_called_once_with(
+        base_model="meta-llama/Llama-3.2-1B",
+        retry_config=retry,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. optim_step passes typed AdamParams positionally
+# ---------------------------------------------------------------------------
+
+def test_optim_step_passes_typed_adam_params():
+    training = MagicMock()
+    adam = tinker_types.AdamParams(learning_rate=1e-5)
+    optim_step(training, adam)
+    training.optim_step.assert_called_once_with(adam)
+    # sanity: no kwargs used
+    _, kwargs = training.optim_step.call_args
+    assert kwargs == {}
+
+
+# ---------------------------------------------------------------------------
+# 6. save_weights_and_get_sampling_client returns result directly
+# ---------------------------------------------------------------------------
+
+def test_save_weights_returns_sampling_client_directly():
+    training = MagicMock()
+    sentinel = MagicMock(name="SamplingClient")
+    training.save_weights_and_get_sampling_client.return_value = sentinel
+
+    out = save_weights_and_get_sampling_client(training, "ckpt-0", retry_config=None)
+
+    assert out is sentinel
+    training.save_weights_and_get_sampling_client.assert_called_once_with(
+        "ckpt-0", retry_config=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fake exception class by name (for error-taxonomy tests)
+# ---------------------------------------------------------------------------
+
+def _make_exc(name: str) -> type[Exception]:
+    return type(name, (Exception,), {})
+
+
+# ---------------------------------------------------------------------------
+# 7. forward_backward wraps RateLimitError as recoverable
+# ---------------------------------------------------------------------------
+
+def test_forward_backward_wraps_rate_limit_as_recoverable():
+    RateLimitError = _make_exc("RateLimitError")
+    training = MagicMock()
+    training.forward_backward.side_effect = RateLimitError("slow down")
+
+    with pytest.raises(TinkerBackendError) as exc_info:
+        forward_backward(training, [], loss_fn="cross_entropy")
+
+    assert exc_info.value.recoverable is True
+    assert exc_info.value.error.recoverable is True
+
+
+# ---------------------------------------------------------------------------
+# 8. forward_backward wraps BadRequestError as non-recoverable
+# ---------------------------------------------------------------------------
+
+def test_forward_backward_wraps_badrequest_as_non_recoverable():
+    BadRequestError = _make_exc("BadRequestError")
+    training = MagicMock()
+    training.forward_backward.side_effect = BadRequestError("bad input")
+
+    with pytest.raises(TinkerBackendError) as exc_info:
+        forward_backward(training, [], loss_fn="cross_entropy")
+
+    assert exc_info.value.recoverable is False
+    assert exc_info.value.error.recoverable is False
+
+
+# ---------------------------------------------------------------------------
+# 9. Error-taxonomy .code assertions + unknown-exception fallthrough
+# ---------------------------------------------------------------------------
+
+def test_forward_backward_wraps_rate_limit_has_backend_unreachable_code():
+    training = MagicMock()
+    exc_cls = type("RateLimitError", (Exception,), {})
+    training.forward_backward.side_effect = exc_cls("429")
+    with pytest.raises(TinkerBackendError) as exc_info:
+        forward_backward(training, [], loss_fn="importance_sampling")
+    assert exc_info.value.code == "backend_unreachable"
+    assert exc_info.value.recoverable is True
+
+
+def test_forward_backward_wraps_badrequest_has_invalid_config_code():
+    training = MagicMock()
+    exc_cls = type("BadRequestError", (Exception,), {})
+    training.forward_backward.side_effect = exc_cls("bad")
+    with pytest.raises(TinkerBackendError) as exc_info:
+        forward_backward(training, [], loss_fn="importance_sampling")
+    assert exc_info.value.code == "invalid_config"
+    assert exc_info.value.recoverable is False
+
+
+def test_forward_backward_unknown_exception_maps_to_unknown_non_recoverable():
+    training = MagicMock()
+    exc_cls = type("WeirdFutureSDKError", (Exception,), {})
+    training.forward_backward.side_effect = exc_cls("surprise")
+    with pytest.raises(TinkerBackendError) as exc_info:
+        forward_backward(training, [], loss_fn="importance_sampling")
+    assert exc_info.value.code == "unknown"
+    assert exc_info.value.recoverable is False
+
+
+# ---------------------------------------------------------------------------
+# 10. async_sample builds ModelInput + SamplingParams correctly
+# ---------------------------------------------------------------------------
+
+def test_async_sample_builds_model_input_and_sampling_params():
+    sampling_client = MagicMock()
+    sampling_client.sample.return_value = MagicMock(name="ConcurrentFuture")
+
+    out = async_sample(
+        sampling_client,
+        prompt_tokens=[1, 2, 3],
+        num_samples=1,
+        max_tokens=8,
+        temperature=0.7,
+        top_p=0.95,
+        stop=None,
+    )
+
+    assert out is sampling_client.sample.return_value
+    sampling_client.sample.assert_called_once()
+    _, kwargs = sampling_client.sample.call_args
+
+    # prompt is a ModelInput with chunks=[EncodedTextChunk(tokens=[1,2,3])]
+    prompt = kwargs["prompt"]
+    assert isinstance(prompt, tinker_types.ModelInput)
+    assert len(prompt.chunks) == 1
+    assert list(prompt.chunks[0].tokens) == [1, 2, 3]
+
+    assert kwargs["num_samples"] == 1
+
+    params = kwargs["sampling_params"]
+    assert isinstance(params, tinker_types.SamplingParams)
+    assert params.max_tokens == 8
+
+
+# ---------------------------------------------------------------------------
+# 11. load_state_with_optimizer forwards the path and unwraps APIFuture
+# ---------------------------------------------------------------------------
+
+def test_load_state_with_optimizer_forwards_path():
+    training = MagicMock()
+    fut = MagicMock()
+    fut.result.return_value = "restored"
+    training.load_state_with_optimizer.return_value = fut
+
+    out = load_state_with_optimizer(training, "tinker://ckpt-7")
+
+    training.load_state_with_optimizer.assert_called_once_with("tinker://ckpt-7")
+    fut.result.assert_called_once_with()
+    assert out == "restored"
+
+
+def test_load_state_with_optimizer_passthrough_when_no_result_attr():
+    training = MagicMock()
+    sentinel = object()
+    # Use SimpleNamespace-like object without .result attr.
+    training.load_state_with_optimizer.return_value = sentinel
+
+    # Patch hasattr behaviour by giving back something without result().
+    class _Bare:
+        pass
+
+    bare = _Bare()
+    training.load_state_with_optimizer.return_value = bare
+    out = load_state_with_optimizer(training, "tinker://ckpt-1")
+    assert out is bare
+
+
+# ---------------------------------------------------------------------------
+# 12. load_state_with_optimizer wraps exceptions via the error taxonomy
+# ---------------------------------------------------------------------------
+
+def test_load_state_with_optimizer_wraps_recoverable_exception():
+    training = MagicMock()
+    exc_cls = type("RateLimitError", (Exception,), {})
+    training.load_state_with_optimizer.side_effect = exc_cls("slow down")
+
+    with pytest.raises(TinkerBackendError) as exc_info:
+        load_state_with_optimizer(training, "tinker://ckpt-0")
+    assert exc_info.value.code == "backend_unreachable"
+    assert exc_info.value.recoverable is True
+
+
+def test_load_state_with_optimizer_wraps_non_recoverable_exception():
+    training = MagicMock()
+    exc_cls = type("BadRequestError", (Exception,), {})
+    training.load_state_with_optimizer.side_effect = exc_cls("bad path")
+
+    with pytest.raises(TinkerBackendError) as exc_info:
+        load_state_with_optimizer(training, "tinker://ckpt-0")
+    assert exc_info.value.code == "invalid_config"
+    assert exc_info.value.recoverable is False


### PR DESCRIPTION
## Summary

A runnable example of doing **reinforcement learning against a LoRA adapter trained on Thinking Machines Lab's managed [Tinker](https://thinkingmachines.ai) service**, using ClawLoop as the orchestration layer and [OpenSpiel](https://github.com/google-deepmind/open_spiel) as a reference environment.

### Start here

\`examples/tinker_weight_demo.py\` — 100-line inline example.
\`examples/blackjack_tinker_pilot.yaml\` + \`examples/blackjack_plus_2048_tinker_pilot.yaml\` — YAMLs consumable by \`scripts/run_pilot.py\`.

\`\`\`bash
uv sync --extra games
uv run python examples/tinker_weight_demo.py
\`\`\`

### The three files worth lifting

If you already have an RL loop and just want the Tinker bits:

- \`clawloop/weight_backends/_tinker_sdk.py\` — thin typed adapter over the \`tinker\` SDK (~300 LoC). One-file drift surface + typed error taxonomy.
- \`clawloop/weight_backends/_tinker_exporter.py\` — \`list[Episode] → list[tinker.Datum]\` with episode-level GRPO baselines, strict token/logprob alignment, zero-variance filtering.
- \`clawloop/weight_backends/tinker.py\` — \`TinkerWeightsBackend\` implementing ClawLoop's backend protocol. Dual save every iter (ephemeral SamplingClient for next rollouts + durable \`tinker://\` path listable via \`RestClient.list_checkpoints\`).

### What each iteration does

1. Refresh \`agent_state.sampling_client\` from \`backend.current_sampling_client()\`.
2. Fan out N episode rollouts via \`asyncio.gather\` + \`asyncio.wrap_future\` (without the wrap, \`.result()\` serializes everything — we measured ~7–8× speedup).
3. Each episode captures \`prompt_tokens\`, \`sampled_tokens\`, \`sampling_logprobs\` on \`StepMeta.info\` at sampling time. No tokenizer round-trip.
4. \`episodes_to_tinker_datums\` applies GRPO (group-mean subtraction per \`task_id\`), drops zero-variance groups, emits one \`tinker.types.Datum\` per LLM turn.
5. \`forward_backward\` + \`optim_step\` submitted back-to-back as futures (same Tinker clock cycle), then awaited together.
6. \`save_state(f\"iter_{i}\")\` writes a durable checkpoint; \`save_weights_and_get_sampling_client\` returns the fresh \`SamplingClient\` for next iter.

### Validated

- 78 unit tests. 4 real Tinker pilot runs (Blackjack smoke, 3-iter Blackjack, 3-iter mixed BJ+2048, 3-iter all-8-games).
- Blackjack showed learning signal (avg reward 0.0 → +0.5 over 3 iters on Qwen3-8B).
- Preflight spike (\`scripts/tinker_preflight.py\`) validated the real SDK surface before integration.
- 2 rounds of Codex review + 1 Gemini review closed all flagged issues.

### Use with another env (Harbor, yours, etc.)

The exporter's only contract with your env is that each rollout's \`Episode\` carries, for every LLM turn, a \`StepMeta.info\` dict with:

- \`prompt_tokens: list[int]\` — exact tokens the SamplingClient saw
- \`sampled_tokens: list[int]\` — exact tokens it emitted
- \`sampling_logprobs: list[float]\` — aligned 1:1

See \`examples/README.md\` for the full \"Would Harbor work?\" discussion.

### Known limits

- Self-play for adversarial / hidden-info games not wired — multi-player OpenSpiel games use a random opponent.
- OpenSpiel's canonical action strings don't always match how an LLM writes moves (chess SAN, hanabi hint codes). Per-game parsers are a clean follow-up.
- 2048's terminal reward only fires at the 2048 tile — rare at 30–50 turns. Intermediate reward shaping is on the roadmap.

## Test plan

- [ ] \`uv sync --extra games\` installs cleanly.
- [ ] \`uv run pytest tests/unit/\` → 78 green (new) + existing tests pass.
- [ ] With \`TINKER_API_KEY\` set: \`uv run python examples/tinker_weight_demo.py\` completes one iter and prints a durable Tinker checkpoint path.
- [ ] 3-iter mixed-game pilot produces a monotonic reward curve in the live viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)