### PR TITLE
feat: add MLflow observability sink

### DIFF
--- a/clawloop/integrations/mlflow.py
+++ b/clawloop/integrations/mlflow.py
@@ -1,0 +1,241 @@
+"""MLflow tracking sink for ClawLoop episode and iteration metrics.
+
+Usage::
+
+    from clawloop.integrations.mlflow import MlflowSink
+
+    sink = MlflowSink(experiment_name="clawloop-experiments")
+    learning_loop(..., after_iteration=sink.after_iteration)
+    sink.finish()
+
+Requires the ``mlflow`` optional extra: ``uv sync --extra mlflow``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from clawloop.core.episode import Episode
+    from clawloop.core.state import StateID
+    from clawloop.core.types import FBResult
+    from clawloop.learning_layers.harness import Harness
+
+_log = logging.getLogger(__name__)
+
+
+class MlflowSink:
+    """Log ClawLoop metrics and artifacts to MLflow.
+
+    Parameters
+    ----------
+    experiment_name:
+        Optional MLflow experiment name.
+    run_name:
+        Optional MLflow run name.
+    tracking_uri:
+        Optional tracking URI passed to ``mlflow.set_tracking_uri``.
+    tags:
+        Optional tags attached to the run.
+    log_episodes:
+        If ``True`` (default), log a JSON artifact with per-episode summaries.
+    """
+
+    def __init__(
+        self,
+        *,
+        experiment_name: str | None = None,
+        run_name: str | None = None,
+        tracking_uri: str | None = None,
+        tags: dict[str, Any] | None = None,
+        log_episodes: bool = True,
+    ) -> None:
+        try:
+            import mlflow  # noqa: F811
+        except ImportError as exc:
+            raise ImportError(
+                "mlflow is required for MlflowSink. Install with: pip install 'clawloop[mlflow]'"
+            ) from exc
+
+        self._mlflow = mlflow
+        self._log_episodes = log_episodes
+        self._step = 0
+        self._run = None
+
+        if tracking_uri is not None:
+            mlflow.set_tracking_uri(tracking_uri)
+        if experiment_name is not None:
+            mlflow.set_experiment(experiment_name)
+
+        self._run = mlflow.start_run(run_name=run_name, tags=tags)
+
+    def log_episodes(
+        self,
+        episodes: list[Episode],
+        *,
+        iteration: int | None = None,
+    ) -> None:
+        """Log aggregate reward metrics and optional episode summaries."""
+        if not episodes:
+            return
+
+        step = iteration if iteration is not None else self._step
+        self._step = step + 1
+
+        try:
+            self._log_reward_scalars(episodes, step)
+            if self._log_episodes:
+                self._log_episode_summaries(episodes, step)
+        except Exception:
+            _log.warning("MlflowSink.log_episodes failed", exc_info=True)
+
+    def log_iteration(
+        self,
+        iteration: int,
+        episodes: list[Episode],
+        fb_results: dict[str, FBResult] | None = None,
+        *,
+        harness: Harness | None = None,
+        state_id: StateID | None = None,
+    ) -> None:
+        """Log a full iteration: rewards, playbook growth, state hashes, and feedback."""
+        self._step = iteration + 1
+
+        try:
+            self._log_reward_scalars(episodes, iteration)
+
+            if harness is not None:
+                self._log_playbook(harness, iteration)
+
+            if state_id is not None:
+                self._log_state_hashes(state_id, iteration)
+
+            if fb_results is not None:
+                self._log_fb_results(fb_results, iteration)
+
+            if self._log_episodes and episodes:
+                self._log_episode_summaries(episodes, iteration)
+        except Exception:
+            _log.warning("MlflowSink.log_iteration failed", exc_info=True)
+
+    def after_iteration(
+        self,
+        iteration: int,
+        agent_state: Any,
+        episodes: list[Episode],
+    ) -> None:
+        """Drop-in ``after_iteration`` callback for :func:`learning_loop`."""
+        from clawloop.learning_layers.harness import Harness
+
+        harness = agent_state.harness if isinstance(agent_state.harness, Harness) else None
+        state_id = agent_state.state_id()
+
+        self.log_iteration(iteration, episodes, harness=harness, state_id=state_id)
+
+    def finish(self) -> None:
+        """Finalize the MLflow run."""
+        try:
+            self._mlflow.end_run()
+        except Exception:
+            _log.warning("MlflowSink.finish failed", exc_info=True)
+
+    def _log_reward_scalars(self, episodes: list[Episode], step: int) -> None:
+        if not episodes:
+            return
+
+        rewards = [ep.summary.effective_reward() for ep in episodes]
+        normalized = [ep.summary.normalized_reward() for ep in episodes]
+
+        metrics: dict[str, float] = {
+            "reward.mean": sum(rewards) / len(rewards),
+            "reward.min": min(rewards),
+            "reward.max": max(rewards),
+            "reward.mean_normalized": sum(normalized) / len(normalized),
+            "episodes.count": float(len(episodes)),
+        }
+
+        signal_sums: dict[str, list[float]] = {}
+        for ep in episodes:
+            for name, sig in ep.summary.signals.items():
+                signal_sums.setdefault(name, []).append(sig.value)
+        for name, values in signal_sums.items():
+            metrics[f"reward.{name}.mean"] = sum(values) / len(values)
+
+        self._mlflow.log_metrics(metrics, step=step)
+
+    def _log_playbook(self, harness: Harness, step: int) -> None:
+        entries = harness.playbook.entries
+        metrics: dict[str, float] = {
+            "playbook.size": float(len(entries)),
+        }
+
+        if entries:
+            scores = [e.effective_score() for e in entries]
+            metrics["playbook.mean_score"] = sum(scores) / len(scores)
+            metrics["playbook.max_score"] = max(scores)
+            metrics["playbook.helpful_total"] = float(sum(e.helpful for e in entries))
+            metrics["playbook.harmful_total"] = float(sum(e.harmful for e in entries))
+            self._mlflow.log_dict(
+                [self._playbook_entry_dict(entry) for entry in entries],
+                artifact_file=f"iterations/{step}/playbook_entries.json",
+            )
+
+        self._mlflow.log_metrics(metrics, step=step)
+
+    def _log_state_hashes(self, state_id: StateID, step: int) -> None:
+        self._mlflow.log_dict(
+            {
+                "combined": state_id.combined_hash,
+                "harness": state_id.harness_hash,
+                "router": state_id.router_hash,
+                "weights": state_id.weights_hash,
+            },
+            artifact_file=f"iterations/{step}/state_hashes.json",
+        )
+
+    def _log_fb_results(self, fb_results: dict[str, FBResult], step: int) -> None:
+        metrics: dict[str, float] = {}
+        artifacts: dict[str, Any] = {}
+        for name, result in fb_results.items():
+            artifacts[name] = {
+                "status": result.status,
+                "metrics": result.metrics or {},
+            }
+            for key, value in (result.metrics or {}).items():
+                if isinstance(value, (int, float, bool)):
+                    metrics[f"fb.{name}.{key}"] = float(value)
+
+        if metrics:
+            self._mlflow.log_metrics(metrics, step=step)
+        if artifacts:
+            self._mlflow.log_dict(artifacts, artifact_file=f"iterations/{step}/fb_results.json")
+
+    def _log_episode_summaries(self, episodes: list[Episode], step: int) -> None:
+        self._mlflow.log_dict(
+            [self._episode_dict(ep) for ep in episodes],
+            artifact_file=f"iterations/{step}/episodes.json",
+        )
+
+    @staticmethod
+    def _episode_dict(ep: Episode) -> dict[str, Any]:
+        return {
+            "episode_id": ep.id,
+            "task_id": ep.task_id,
+            "bench": ep.bench,
+            "state_id": ep.state_id,
+            "model": ep.model,
+            "effective_reward": ep.summary.effective_reward(),
+            "normalized_reward": ep.summary.normalized_reward(),
+            "n_steps": ep.n_steps(),
+            "n_messages": len(ep.messages),
+            "filtered": ep.summary.filtered,
+        }
+
+    @staticmethod
+    def _playbook_entry_dict(entry: Any) -> dict[str, Any]:
+        return {
+            "score": entry.effective_score(),
+            "helpful": entry.helpful,
+            "harmful": entry.harmful,
+        }

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,3 @@
+# Observability Sinks
+
+ClawLoop observability sinks are optional adapters that consume episode and iteration data without changing the learning loop. Use `WandbSink` with `uv sync --extra wandb` to log reward curves and episode tables to Weights & Biases, or `MlflowSink` with `uv sync --extra mlflow` to log reward metrics, state hashes, playbook artifacts, and episode summaries to MLflow. Sinks are designed to fail soft so a backend outage does not break a training run.

--- a/examples/observability/mlflow_sink_demo.py
+++ b/examples/observability/mlflow_sink_demo.py
@@ -1,0 +1,59 @@
+"""Minimal example: MlflowSink logging ClawLoop episode metrics to MLflow.
+
+Run with::
+
+    uv sync --extra mlflow
+    python examples/observability/mlflow_sink_demo.py
+
+Or use the sink as a learning-loop callback::
+
+    from clawloop.integrations.mlflow import MlflowSink
+
+    sink = MlflowSink(experiment_name="clawloop-demo")
+    learning_loop(..., after_iteration=sink.after_iteration)
+    sink.finish()
+"""
+
+from clawloop.core.episode import Episode, EpisodeSummary, Message, StepMeta, Timing, TokenUsage
+from clawloop.core.reward import RewardSignal
+from clawloop.integrations.mlflow import MlflowSink
+
+
+def _make_demo_episode(iteration: int) -> Episode:
+    reward_value = min(0.5 + iteration * 0.1, 1.0)
+    mapped = reward_value * 2.0 - 1.0
+
+    return Episode(
+        id=f"ep-{iteration:04d}",
+        state_id=f"state-{iteration}",
+        task_id="demo-task",
+        bench="demo",
+        messages=[
+            Message(role="user", content=f"Iteration {iteration} input"),
+            Message(role="assistant", content=f"Iteration {iteration} response"),
+        ],
+        step_boundaries=[0],
+        steps=[StepMeta(t=0, reward=reward_value, done=True, timing_ms=150.0)],
+        summary=EpisodeSummary(
+            signals={"outcome": RewardSignal(name="outcome", value=mapped, confidence=1.0)},
+            token_usage=TokenUsage(prompt_tokens=30, completion_tokens=20, total_tokens=50),
+            timing=Timing(total_ms=150.0, per_step_ms=[150.0]),
+        ),
+        model="gpt-4o-mini",
+    )
+
+
+def main() -> None:
+    sink = MlflowSink(experiment_name="clawloop-demo", run_name="mlflow-sink-demo")
+
+    for i in range(10):
+        episodes = [_make_demo_episode(i) for _ in range(4)]
+        sink.log_episodes(episodes, iteration=i)
+        print(f"Logged iteration {i}")
+
+    sink.finish()
+    print("Done - run `mlflow ui` to inspect the run.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ car = [
 wandb = [
     "wandb>=0.26",
 ]
+mlflow = [
+    "mlflow>=2.10",
+]
 otel = [
     "opentelemetry-api>=1.20",
     "opentelemetry-sdk>=1.20",

--- a/tests/test_mlflow_sink.py
+++ b/tests/test_mlflow_sink.py
@@ -1,0 +1,240 @@
+"""Tests for clawloop.integrations.mlflow — MlflowSink."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from clawloop.core.episode import Episode, EpisodeSummary, Message, StepMeta, Timing, TokenUsage
+from clawloop.core.reward import RewardSignal
+from clawloop.core.state import StateID
+
+_METRICS: list[tuple[dict[str, float], int | None]] = []
+_ARTIFACTS: list[tuple[Any, str]] = []
+_ENDED: list[bool] = []
+
+
+class _FakeRun:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class _FakeMlflow:
+    _last_run: _FakeRun | None = None
+    _tracking_uri: str | None = None
+    _experiment_name: str | None = None
+
+    @staticmethod
+    def set_tracking_uri(uri: str) -> None:
+        _FakeMlflow._tracking_uri = uri
+
+    @staticmethod
+    def set_experiment(name: str) -> None:
+        _FakeMlflow._experiment_name = name
+
+    @staticmethod
+    def start_run(**kwargs: Any) -> _FakeRun:
+        run = _FakeRun(**kwargs)
+        _FakeMlflow._last_run = run
+        return run
+
+    @staticmethod
+    def log_metrics(metrics: dict[str, float], step: int | None = None) -> None:
+        _METRICS.append((dict(metrics), step))
+
+    @staticmethod
+    def log_dict(dictionary: Any, artifact_file: str) -> None:
+        _ARTIFACTS.append((dictionary, artifact_file))
+
+    @staticmethod
+    def end_run() -> None:
+        _ENDED.append(True)
+
+
+@pytest.fixture(autouse=True)
+def _reset_logged():
+    _METRICS.clear()
+    _ARTIFACTS.clear()
+    _ENDED.clear()
+    _FakeMlflow._last_run = None
+    _FakeMlflow._tracking_uri = None
+    _FakeMlflow._experiment_name = None
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_mlflow():
+    original = sys.modules.get("mlflow")
+    sys.modules["mlflow"] = _FakeMlflow  # type: ignore[assignment]
+    yield
+    if original is not None:
+        sys.modules["mlflow"] = original
+    else:
+        sys.modules.pop("mlflow", None)
+
+
+from clawloop.integrations.mlflow import MlflowSink  # noqa: E402
+
+_BASE_TS = 1_700_000_000.0
+
+
+def _make_episode(
+    *,
+    reward: float = 0.8,
+    episode_id: str = "ep-001",
+    task_id: str = "task-1",
+    bench: str = "test",
+) -> Episode:
+    mapped = reward * 2.0 - 1.0
+    signals = {
+        "outcome": RewardSignal(name="outcome", value=mapped, confidence=1.0),
+        "execution": RewardSignal(name="execution", value=0.5, confidence=0.9),
+    }
+    return Episode(
+        id=episode_id,
+        state_id="state-abc123",
+        task_id=task_id,
+        bench=bench,
+        messages=[
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="hello"),
+        ],
+        step_boundaries=[0],
+        steps=[StepMeta(t=0, reward=reward, done=True, timing_ms=100.0)],
+        summary=EpisodeSummary(
+            signals=signals,
+            token_usage=TokenUsage(prompt_tokens=50, completion_tokens=20, total_tokens=70),
+            timing=Timing(total_ms=100.0, per_step_ms=[100.0]),
+        ),
+        model="gpt-4o",
+        created_at=_BASE_TS,
+    )
+
+
+def _find_metric(key: str) -> list[tuple[float, int | None]]:
+    results = []
+    for metrics, step in _METRICS:
+        if key in metrics:
+            results.append((metrics[key], step))
+    return results
+
+
+class TestInit:
+    def test_basic_init(self) -> None:
+        sink = MlflowSink()
+        assert sink._run is not None
+
+    def test_init_options_passed(self) -> None:
+        MlflowSink(
+            experiment_name="clawloop-demo",
+            run_name="run-1",
+            tracking_uri="file:///tmp/mlruns",
+            tags={"suite": "demo"},
+        )
+
+        assert _FakeMlflow._tracking_uri == "file:///tmp/mlruns"
+        assert _FakeMlflow._experiment_name == "clawloop-demo"
+        assert _FakeMlflow._last_run is not None
+        assert _FakeMlflow._last_run.kwargs["run_name"] == "run-1"
+        assert _FakeMlflow._last_run.kwargs["tags"] == {"suite": "demo"}
+
+    def test_import_error_without_mlflow(self) -> None:
+        original = sys.modules.get("mlflow")
+        sys.modules["mlflow"] = None  # type: ignore[assignment]
+        try:
+            with pytest.raises(ImportError, match="mlflow"):
+                MlflowSink()
+        finally:
+            if original is not None:
+                sys.modules["mlflow"] = original
+
+
+class TestLogEpisodes:
+    def test_reward_scalars_logged(self) -> None:
+        sink = MlflowSink()
+        sink.log_episodes([_make_episode(reward=0.8)], iteration=0)
+
+        means = _find_metric("reward.mean")
+        assert len(means) == 1
+        assert abs(means[0][0] - 0.6) < 1e-6
+        assert means[0][1] == 0
+
+    def test_episode_summaries_logged_as_artifact(self) -> None:
+        sink = MlflowSink()
+        sink.log_episodes([_make_episode()], iteration=2)
+
+        assert len(_ARTIFACTS) == 1
+        payload, artifact_file = _ARTIFACTS[0]
+        assert artifact_file == "iterations/2/episodes.json"
+        assert payload[0]["episode_id"] == "ep-001"
+
+    def test_episode_artifact_can_be_disabled(self) -> None:
+        sink = MlflowSink(log_episodes=False)
+        sink.log_episodes([_make_episode()], iteration=0)
+
+        assert _ARTIFACTS == []
+
+    def test_empty_episodes_noop(self) -> None:
+        sink = MlflowSink()
+        sink.log_episodes([], iteration=0)
+
+        assert _METRICS == []
+        assert _ARTIFACTS == []
+
+    def test_auto_step_increments(self) -> None:
+        sink = MlflowSink()
+        sink.log_episodes([_make_episode()])
+        sink.log_episodes([_make_episode()])
+
+        steps = [step for _, step in _METRICS]
+        assert 0 in steps
+        assert 1 in steps
+
+
+class TestLogIteration:
+    def test_playbook_and_state_artifacts_logged(self) -> None:
+        sink = MlflowSink()
+        harness = MagicMock()
+        entry = MagicMock()
+        entry.effective_score.return_value = 2.0
+        entry.helpful = 5
+        entry.harmful = 1
+        harness.playbook.entries = [entry]
+        sid = StateID(
+            harness_hash="aabbccddee11" * 6,
+            router_hash="112233445566" * 6,
+            weights_hash="ffeeddccbbaa" * 6,
+            combined_hash="abcdef012345" * 6,
+            created_at=_BASE_TS,
+        )
+
+        sink.log_iteration(3, [_make_episode()], harness=harness, state_id=sid)
+
+        assert _find_metric("playbook.size")[0] == (1.0, 3)
+        artifact_files = {artifact_file for _, artifact_file in _ARTIFACTS}
+        assert "iterations/3/playbook_entries.json" in artifact_files
+        assert "iterations/3/state_hashes.json" in artifact_files
+
+    def test_log_iteration_syncs_auto_step(self) -> None:
+        sink = MlflowSink()
+        sink.log_iteration(5, [_make_episode()])
+        sink.log_episodes([_make_episode()])
+
+        steps = [step for _, step in _METRICS]
+        assert 6 in steps
+
+    def test_backend_errors_fail_soft(self) -> None:
+        sink = MlflowSink()
+        sink._mlflow.log_metrics = MagicMock(side_effect=RuntimeError("backend down"))
+
+        sink.log_episodes([_make_episode()], iteration=0)
+
+
+class TestFinish:
+    def test_finish_ends_run(self) -> None:
+        sink = MlflowSink()
+        sink.finish()
+
+        assert _ENDED == [True]


### PR DESCRIPTION
## Summary

Adds the MLflow tracking sink from the observability integrations umbrella:

- `clawloop.integrations.mlflow.MlflowSink`
- optional `mlflow` extra
- reward, per-signal, playbook, state hash, feedback, and episode-summary logging
- fail-soft logging so MLflow backend failures do not break a training run
- minimal MLflow example under `examples/observability/`
- observability README covering W&B and MLflow sinks

## Scope

This implements the MLflow subtask from #52 only. It does not attempt to complete the Langfuse, Phoenix, or other remaining integration items.

The sink follows the existing W&B adapter shape: lazy optional dependency import, `log_episodes`, `log_iteration`, `after_iteration`, and `finish`.

## Verification

- `python -m pytest tests/test_mlflow_sink.py`
- `python -m pytest tests/test_wandb_sink.py tests/test_mlflow_sink.py`
- `python -m ruff check clawloop/integrations/mlflow.py tests/test_mlflow_sink.py examples/observability/mlflow_sink_demo.py`
- `python -m ruff format --check clawloop/integrations/mlflow.py tests/test_mlflow_sink.py examples/observability/mlflow_sink_demo.py`
